### PR TITLE
팀 정보 확인 수정 및 상세 조회 추가

### DIFF
--- a/src/main/java/sharev/domain/gathering/entity/Gathering.java
+++ b/src/main/java/sharev/domain/gathering/entity/Gathering.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 import org.hibernate.annotations.UuidGenerator.Style;
 import sharev.base_entity.BaseTimeEntity;
@@ -22,6 +23,7 @@ import sharev.domain.team.entity.Team;
 @Getter
 @NoArgsConstructor
 @Table(name = "gatherings")
+@SQLRestriction("deleted_at IS NULL")
 public class Gathering extends BaseTimeEntity {
 
     @Id

--- a/src/main/java/sharev/domain/member/service/MemberService.java
+++ b/src/main/java/sharev/domain/member/service/MemberService.java
@@ -1,0 +1,36 @@
+package sharev.domain.member.service;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import sharev.domain.account.entity.Account;
+import sharev.domain.member.entity.Member;
+import sharev.domain.member.entity.MemberRoleType;
+import sharev.domain.member.repository.MemberRepository;
+import sharev.domain.team.entity.Team;
+import sharev.domain.team.exception.TeamNotFoundException;
+import sharev.domain.team.repository.TeamRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MemberService {
+    private final TeamRepository teamRepository;
+    private final MemberRepository memberRepository;
+
+    public boolean isAdmin(Account account, Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(TeamNotFoundException::new);
+
+        Optional<Member> optionalMember = memberRepository.findByTeamAndAccount(team, account);
+
+        if (optionalMember.isEmpty()) {
+            throw new TeamNotFoundException();
+        }
+
+        Member member = optionalMember.get();
+
+        return member.getRole() == MemberRoleType.ADMIN;
+    }
+}

--- a/src/main/java/sharev/domain/team/controller/TeamController.java
+++ b/src/main/java/sharev/domain/team/controller/TeamController.java
@@ -18,6 +18,7 @@ import sharev.domain.account.entity.Account;
 import sharev.domain.team.dto.request.RequestCreateTeamDto;
 import sharev.domain.team.dto.request.RequestUpdateTeamDto;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
+import sharev.domain.team.dto.response.ResponseTeamUpdateInfoDto;
 import sharev.domain.team.service.TeamService;
 
 @RestController
@@ -42,11 +43,11 @@ public class TeamController {
     // TODO: GET /{teamId} 팀 상세 정보(행사 목록, 멤버 목록, 팀명)
 
     @PatchMapping("/{teamId}")
-    @PreAuthorize("@teamService.isMember(authentication.principal, #teamId)")
-    public ResponseEntity<Void> updateTeamInfo(@PathVariable Long teamId,
-                                               @RequestBody RequestUpdateTeamDto requestUpdateTeamDto) {
-        teamService.updateTeamInfo(teamId, requestUpdateTeamDto.title());
-        return ResponseEntity.ok()
-                .build();
+    @PreAuthorize("@memberService.isAdmin(authentication.principal, #teamId)")
+    public ResponseEntity<ResponseTeamUpdateInfoDto> updateTeamInfo(@PathVariable Long teamId,
+                                                                    @RequestBody RequestUpdateTeamDto updateTeamDto) {
+
+        String updateTitle = teamService.updateTeamInfo(teamId, updateTeamDto.title());
+        return ResponseEntity.ok(new ResponseTeamUpdateInfoDto(updateTitle));
     }
 }

--- a/src/main/java/sharev/domain/team/controller/TeamController.java
+++ b/src/main/java/sharev/domain/team/controller/TeamController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
 import sharev.domain.account.entity.Account;
 import sharev.domain.team.dto.request.RequestCreateTeamDto;
 import sharev.domain.team.dto.request.RequestUpdateTeamDto;
+import sharev.domain.team.dto.response.ResponseTeamDetailInfoDto;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
 import sharev.domain.team.dto.response.ResponseTeamUpdateInfoDto;
 import sharev.domain.team.service.TeamService;
@@ -40,7 +41,11 @@ public class TeamController {
         return ResponseEntity.ok(teamService.getMyTeams(account));
     }
 
-    // TODO: GET /{teamId} 팀 상세 정보(행사 목록, 멤버 목록, 팀명)
+    @GetMapping("/{teamId}")
+    @PreAuthorize("@teamService.isMember(authentication.principal, #teamId)")
+    public ResponseEntity<ResponseTeamDetailInfoDto> getTeamDetail(@PathVariable Long teamId) {
+        return ResponseEntity.ok(teamService.getTeamDetail(teamId));
+    }
 
     @PatchMapping("/{teamId}")
     @PreAuthorize("@memberService.isAdmin(authentication.principal, #teamId)")

--- a/src/main/java/sharev/domain/team/dto/response/ResponseTeamDetailInfoDto.java
+++ b/src/main/java/sharev/domain/team/dto/response/ResponseTeamDetailInfoDto.java
@@ -1,0 +1,42 @@
+package sharev.domain.team.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import sharev.domain.gathering.entity.Gathering;
+import sharev.domain.team.entity.Team;
+
+public record ResponseTeamDetailInfoDto(
+        Long id,
+        String title,
+        String content,
+        LocalDateTime createdAt,
+        int headcount,
+        List<GatheringInfoDto> gatherings,
+        List<TeamMemberInfoDto> members
+) {
+    record GatheringInfoDto(
+            String title,
+            LocalDateTime startAt,
+            LocalDateTime endAt,
+            String place
+    ) {
+        GatheringInfoDto(Gathering gathering) {
+            this(gathering.getTitle(), gathering.getStartAt(), gathering.getEndAt(), gathering.getPlace());
+        }
+    }
+
+    record TeamMemberInfoDto(
+            String name,
+            String email
+    ) {
+        TeamMemberInfoDto(TempTeamMemberInfoDto teamMember) {
+            this(teamMember.name(), teamMember.email());
+        }
+    }
+
+    public ResponseTeamDetailInfoDto(Team team, List<Gathering> gatherings, List<TempTeamMemberInfoDto> teamMembers) {
+        this(team.getId(), team.getTitle(), team.getContent(), team.getCreatedAt(), teamMembers.size(),
+                gatherings.stream().map(GatheringInfoDto::new).toList(),
+                teamMembers.stream().map(TeamMemberInfoDto::new).toList());
+    }
+}

--- a/src/main/java/sharev/domain/team/dto/response/ResponseTeamInfoDto.java
+++ b/src/main/java/sharev/domain/team/dto/response/ResponseTeamInfoDto.java
@@ -2,12 +2,14 @@ package sharev.domain.team.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
+import sharev.domain.member.entity.MemberRoleType;
 
 public record ResponseTeamInfoDto(
         Long id,
         String title,
         String content,
         LocalDateTime createdAt,
+        MemberRoleType memberRoleType,
         int headcount
 ) {
 

--- a/src/main/java/sharev/domain/team/dto/response/ResponseTeamUpdateInfoDto.java
+++ b/src/main/java/sharev/domain/team/dto/response/ResponseTeamUpdateInfoDto.java
@@ -1,0 +1,6 @@
+package sharev.domain.team.dto.response;
+
+public record ResponseTeamUpdateInfoDto(
+        String title
+) {
+}

--- a/src/main/java/sharev/domain/team/dto/response/TempTeamMemberInfoDto.java
+++ b/src/main/java/sharev/domain/team/dto/response/TempTeamMemberInfoDto.java
@@ -1,0 +1,13 @@
+package sharev.domain.team.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+
+public record TempTeamMemberInfoDto(
+        String name,
+        String email
+) {
+
+    @QueryProjection
+    public TempTeamMemberInfoDto {
+    }
+}

--- a/src/main/java/sharev/domain/team/repository/TeamRepositoryCustom.java
+++ b/src/main/java/sharev/domain/team/repository/TeamRepositoryCustom.java
@@ -2,7 +2,11 @@ package sharev.domain.team.repository;
 
 import java.util.List;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
+import sharev.domain.team.dto.response.TempTeamMemberInfoDto;
 
 public interface TeamRepositoryCustom {
+
     List<ResponseTeamInfoDto> findMyTeams(Long accountId);
+
+    List<TempTeamMemberInfoDto> findMyTeamMembers(Long teamId);
 }

--- a/src/main/java/sharev/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/sharev/domain/team/repository/TeamRepositoryImpl.java
@@ -1,5 +1,6 @@
 package sharev.domain.team.repository;
 
+import static sharev.domain.account.entity.QAccount.account;
 import static sharev.domain.member.entity.QMember.member;
 import static sharev.domain.team.entity.QTeam.team;
 
@@ -9,7 +10,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import sharev.domain.member.entity.QMember;
 import sharev.domain.team.dto.response.QResponseTeamInfoDto;
+import sharev.domain.team.dto.response.QTempTeamMemberInfoDto;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
+import sharev.domain.team.dto.response.TempTeamMemberInfoDto;
 
 @RequiredArgsConstructor
 public class TeamRepositoryImpl implements TeamRepositoryCustom {
@@ -36,6 +39,21 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
                 .on(member.team.eq(team))
 
                 .where(member.account.id.eq(accountId))
+                .fetch();
+    }
+
+    public List<TempTeamMemberInfoDto> findMyTeamMembers(Long teamId) {
+        return queryFactory
+                .select(new QTempTeamMemberInfoDto(
+                        account.name,
+                        account.email
+                ))
+                .from(member)
+
+                .leftJoin(account)
+                .on(member.account.eq(account))
+
+                .where(member.team.id.eq(teamId))
                 .fetch();
     }
 }

--- a/src/main/java/sharev/domain/team/repository/TeamRepositoryImpl.java
+++ b/src/main/java/sharev/domain/team/repository/TeamRepositoryImpl.java
@@ -24,6 +24,7 @@ public class TeamRepositoryImpl implements TeamRepositoryCustom {
                         team.title,
                         team.content,
                         team.createdAt,
+                        member.role,
                         JPAExpressions
                                 .select(teamMember.count().intValue())
                                 .from(teamMember)

--- a/src/main/java/sharev/domain/team/service/TeamService.java
+++ b/src/main/java/sharev/domain/team/service/TeamService.java
@@ -7,11 +7,15 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sharev.domain.account.entity.Account;
+import sharev.domain.gathering.entity.Gathering;
+import sharev.domain.gathering.repository.GatheringRepository;
 import sharev.domain.member.entity.Member;
 import sharev.domain.member.entity.MemberRoleType;
 import sharev.domain.member.entity.MemberStatusType;
 import sharev.domain.member.repository.MemberRepository;
+import sharev.domain.team.dto.response.ResponseTeamDetailInfoDto;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
+import sharev.domain.team.dto.response.TempTeamMemberInfoDto;
 import sharev.domain.team.entity.Team;
 import sharev.domain.team.exception.TeamNameDuplicateException;
 import sharev.domain.team.exception.TeamNotFoundException;
@@ -23,6 +27,7 @@ import sharev.domain.team.repository.TeamRepository;
 public class TeamService {
     private final TeamRepository teamRepository;
     private final MemberRepository memberRepository;
+    private final GatheringRepository gatheringRepository;
 
     @Transactional
     public void create(Account account, String title) {
@@ -59,5 +64,16 @@ public class TeamService {
         team.updateTitle(title);
 
         return team.getTitle();
+    }
+
+    public ResponseTeamDetailInfoDto getTeamDetail(Long teamId) {
+        Team team = teamRepository.findById(teamId)
+                .orElseThrow(TeamNotFoundException::new);
+
+        List<Gathering> gatherings = gatheringRepository.findAllByTeam(team);
+
+        List<TempTeamMemberInfoDto> teamMembers = teamRepository.findMyTeamMembers(teamId);
+
+        return new ResponseTeamDetailInfoDto(team, gatherings, teamMembers);
     }
 }

--- a/src/main/java/sharev/domain/team/service/TeamService.java
+++ b/src/main/java/sharev/domain/team/service/TeamService.java
@@ -52,10 +52,12 @@ public class TeamService {
     }
 
     @Transactional
-    public void updateTeamInfo(Long teamId, String title) {
+    public String updateTeamInfo(Long teamId, String title) {
         Team team = teamRepository.findById(teamId)
                 .orElseThrow(TeamNotFoundException::new);
 
         team.updateTitle(title);
+
+        return team.getTitle();
     }
 }

--- a/src/test/java/sharev/ControllerTestSupport.java
+++ b/src/test/java/sharev/ControllerTestSupport.java
@@ -18,6 +18,7 @@ import sharev.domain.account.service.AccountService;
 import sharev.domain.account.service.CustomOauth2UserService;
 import sharev.domain.card.service.CardService;
 import sharev.domain.connection.service.ConnectionService;
+import sharev.domain.member.service.MemberService;
 import sharev.domain.team.service.TeamService;
 import sharev.util.LockProcessor;
 
@@ -56,4 +57,7 @@ public abstract class ControllerTestSupport {
 
     @MockitoBean
     protected LockProcessor lockProcessor;
+
+    @MockitoBean
+    protected MemberService memberService;
 }

--- a/src/test/java/sharev/domain/team/controller/TeamControllerTest.java
+++ b/src/test/java/sharev/domain/team/controller/TeamControllerTest.java
@@ -155,8 +155,6 @@ class TeamControllerTest extends ControllerTestSupport {
         String updateTitle = "수정된 팀 이름";
         RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto(updateTitle);
 
-        doReturn(updateTitle).when(teamService).updateTeamInfo(anyLong(), anyString());
-
         RequestBuilder request = RestDocumentationRequestBuilders
                 .patch("/teams/{teamId}", teamId)
                 .content(objectMapper.writeValueAsString(requestDto))
@@ -176,7 +174,6 @@ class TeamControllerTest extends ControllerTestSupport {
         RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto(updateTitle);
 
         doReturn(false).when(memberService).isAdmin(any(Account.class), anyLong());
-        doReturn(updateTitle).when(teamService).updateTeamInfo(anyLong(), anyString());
 
         RequestBuilder request = RestDocumentationRequestBuilders
                 .patch("/teams/{teamId}", teamId)
@@ -210,11 +207,13 @@ class TeamControllerTest extends ControllerTestSupport {
                 .andDo(document("updateTeamInfo",
                         resource(ResourceSnippetParameters.builder()
                                 .summary("팀 정보 수정")
-                                .description("팀 정보를 수정합니다. 팀 멤버만 수정할 수 있습니다.")
+                                .description("팀 정보를 수정합니다. 팀 관리자만 수정할 수 있습니다.")
                                 .pathParameters(
                                         parameterWithName("teamId").description("팀 ID"))
                                 .requestFields(
                                         fieldWithPath("title").type(STRING).description("팀 이름"))
+                                .responseFields(
+                                        fieldWithPath("title").type(STRING).description("수정된 팀 이름"))
                                 .requestSchema(schema(RequestUpdateTeamDto.class.getSimpleName()))
                                 .build())));
     }

--- a/src/test/java/sharev/domain/team/controller/TeamControllerTest.java
+++ b/src/test/java/sharev/domain/team/controller/TeamControllerTest.java
@@ -6,7 +6,9 @@ import static com.epages.restdocs.apispec.ResourceDocumentation.resource;
 import static com.epages.restdocs.apispec.Schema.schema;
 import static com.epages.restdocs.apispec.SimpleType.NUMBER;
 import static com.epages.restdocs.apispec.SimpleType.STRING;
-import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -23,8 +25,11 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.test.web.servlet.RequestBuilder;
 import sharev.ControllerTestSupport;
 import sharev.WithCustomMockUser;
+import sharev.domain.account.entity.Account;
+import sharev.domain.member.entity.MemberRoleType;
 import sharev.domain.team.dto.request.RequestCreateTeamDto;
 import sharev.domain.team.dto.request.RequestUpdateTeamDto;
+import sharev.domain.team.dto.response.ResponseTeamDetailInfoDto;
 import sharev.domain.team.dto.response.ResponseTeamInfoDto;
 
 class TeamControllerTest extends ControllerTestSupport {
@@ -60,8 +65,8 @@ class TeamControllerTest extends ControllerTestSupport {
     @DisplayName("내 팀 목록 조회")
     void getMyTeams() throws Exception {
         List<ResponseTeamInfoDto> teams = List.of(
-                new ResponseTeamInfoDto(1L, "개발팀", "개발 관련 팀", LocalDateTime.now(), 5),
-                new ResponseTeamInfoDto(2L, "기획팀", "기획 관련 팀", LocalDateTime.now(), 3)
+                new ResponseTeamInfoDto(1L, "개발팀", "개발 관련 팀", LocalDateTime.now(), MemberRoleType.COMMON, 5),
+                new ResponseTeamInfoDto(2L, "기획팀", "기획 관련 팀", LocalDateTime.now(), MemberRoleType.COMMON, 3)
         );
 
         doReturn(teams).when(teamService).getMyTeams(any());
@@ -82,8 +87,105 @@ class TeamControllerTest extends ControllerTestSupport {
                                         fieldWithPath("[].title").type(STRING).description("팀 이름"),
                                         fieldWithPath("[].content").type(STRING).description("팀 설명").optional(),
                                         fieldWithPath("[].createdAt").type(STRING).description("생성일시"),
+                                        fieldWithPath("[].memberRoleType").type(STRING).description("권한"),
                                         fieldWithPath("[].headcount").type(NUMBER).description("팀 인원 수"))
                                 .build())));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("팀 상세 조회 실패 - 팀 미존재 혹은 속하지 않음")
+    void getTeamDetailFail() throws Exception {
+        Long teamId = 1L;
+
+        RequestBuilder request = RestDocumentationRequestBuilders
+                .get("/teams/{teamId}", teamId)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(request)
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("팀 상세 조회")
+    void getTeamDetail() throws Exception {
+        Long teamId = 1L;
+
+        ResponseTeamDetailInfoDto response = new ResponseTeamDetailInfoDto(
+                1L, "개발팀", "개발 관련 팀", LocalDateTime.now(), 2,
+                List.of(),
+                List.of()
+        );
+
+        doReturn(true).when(teamService).isMember(any(Account.class), anyLong());
+        doReturn(response).when(teamService).getTeamDetail(anyLong());
+
+        RequestBuilder request = RestDocumentationRequestBuilders
+                .get("/teams/{teamId}", teamId)
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(request)
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("getTeamDetail",
+                        resource(ResourceSnippetParameters.builder()
+                                .summary("팀 상세 조회")
+                                .description("팀 상세 정보를 조회합니다. 팀 멤버만 조회할 수 있습니다.")
+                                .pathParameters(
+                                        parameterWithName("teamId").description("팀 ID"))
+                                .responseFields(
+                                        fieldWithPath("id").type(NUMBER).description("팀 ID"),
+                                        fieldWithPath("title").type(STRING).description("팀 이름"),
+                                        fieldWithPath("content").type(STRING).description("팀 설명").optional(),
+                                        fieldWithPath("createdAt").type(STRING).description("생성일시"),
+                                        fieldWithPath("headcount").type(NUMBER).description("팀 인원 수"),
+                                        fieldWithPath("gatherings").type("ARRAY").description("행사 목록"),
+                                        fieldWithPath("members").type("ARRAY").description("멤버 목록"))
+                                .responseSchema(schema(ResponseTeamDetailInfoDto.class.getSimpleName()))
+                                .build())));
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("팀 정보 수정 실패 - 팀 미존재 혹은 속하지 않음")
+    void updateTeamInfoTeamFail() throws Exception {
+        Long teamId = 1L;
+        String updateTitle = "수정된 팀 이름";
+        RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto(updateTitle);
+
+        doReturn(updateTitle).when(teamService).updateTeamInfo(anyLong(), anyString());
+
+        RequestBuilder request = RestDocumentationRequestBuilders
+                .patch("/teams/{teamId}", teamId)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(request)
+                .andDo(print())
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @WithCustomMockUser
+    @DisplayName("팀 정보 수정 실패 - 권한 없음")
+    void updateTeamInfoRoleFail() throws Exception {
+        Long teamId = 1L;
+        String updateTitle = "수정된 팀 이름";
+        RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto(updateTitle);
+
+        doReturn(false).when(memberService).isAdmin(any(Account.class), anyLong());
+        doReturn(updateTitle).when(teamService).updateTeamInfo(anyLong(), anyString());
+
+        RequestBuilder request = RestDocumentationRequestBuilders
+                .patch("/teams/{teamId}", teamId)
+                .content(objectMapper.writeValueAsString(requestDto))
+                .contentType(MediaType.APPLICATION_JSON);
+
+        mockMvc.perform(request)
+                .andDo(print())
+                .andExpect(status().isNotFound());
     }
 
     @Test
@@ -91,10 +193,11 @@ class TeamControllerTest extends ControllerTestSupport {
     @DisplayName("팀 정보 수정")
     void updateTeamInfo() throws Exception {
         Long teamId = 1L;
-        RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto("수정된 팀 이름");
+        String updateTitle = "수정된 팀 이름";
+        RequestUpdateTeamDto requestDto = new RequestUpdateTeamDto(updateTitle);
 
-        doReturn(true).when(teamService).isMember(any(), anyLong());
-        doNothing().when(teamService).updateTeamInfo(anyLong(), anyString());
+        doReturn(true).when(memberService).isAdmin(any(Account.class), anyLong());
+        doReturn(updateTitle).when(teamService).updateTeamInfo(anyLong(), anyString());
 
         RequestBuilder request = RestDocumentationRequestBuilders
                 .patch("/teams/{teamId}", teamId)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 팀 상세 조회 엔드포인트 추가 — 모임 목록 및 멤버 정보(이름, 이메일) 포함
  * 팀 수정 시 업데이트된 제목을 응답으로 반환

* **개선**
  * 팀 목록/상세에 멤버 역할 표시 추가
  * 팀 수정 권한을 어드민으로 강화 (어드민만 수정 가능)
  * 모임 조회 시 삭제된 모임은 자동으로 제외되도록 필터링 적용
<!-- end of auto-generated comment: release notes by coderabbit.ai -->