### PR TITLE
account 정보 수정 시 하나의 api에서 link 추가, 삭제할 수 있도록 구성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,17 +21,10 @@ plugins {
 
 group = 'sharev'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '17'
 
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
-    }
-}
-
-configurations {
-    compileOnly {
-        extendsFrom annotationProcessor
     }
 }
 
@@ -181,18 +174,11 @@ swaggerSources {
 }
 
 tasks.register("copySwaggerUISample") {
+    dependsOn generateSwaggerUISample
     doLast {
-        def destinationDir
-
-        if ("${profile}" == 'dev') {
-            destinationDir = "${layout.buildDirectory.dir("resources/main/static/docs/").get()}"
-        } else {
-            destinationDir = "src/main/resources/static/docs/"
-        }
-
         copy {
             from("${generateSwaggerUISample.outputDir}")
-            into(destinationDir)
+            into("${layout.buildDirectory.dir("resources/main/static/docs/").get()}")
         }
     }
 }
@@ -204,7 +190,13 @@ tasks.withType(GenerateSwaggerUI).configureEach {
 
 bootJar {
     if ("${profile}" != 'prod') {
-        dependsOn generateSwaggerUISample
+        dependsOn copySwaggerUISample
+    }
+}
+
+bootRun {
+    if ("${profile}" != 'prod') {
+        dependsOn copySwaggerUISample
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -200,8 +200,4 @@ bootRun {
     }
 }
 
-clean {
-    delete file("src/main/resources/static/docs/")
-}
-
 // === swagger end ===

--- a/src/main/kotlin/sharev/account/adapter/inbound/web/controller/AccountController.kt
+++ b/src/main/kotlin/sharev/account/adapter/inbound/web/controller/AccountController.kt
@@ -43,8 +43,7 @@ class AccountController(
         updateSessionInfo(accountPrincipal.updateFrom(result), httpSession)
 
         return ResponseEntity.ok(result.toUpdateAccountInfoResponse())
-    } // TODO: 계정 업데이트 시 추가 링크 목록, 삭제 링크 목록을 받아 추가하거나 삭제할 것
-    // TODO: 이벤트로 넘기되 비동기 쓰지 말고, 같은 트랜잭션 내에서 동작하게끔 수정할 것
+    }
 
     @GetMapping
     fun getAccountInfo(

--- a/src/main/kotlin/sharev/account/adapter/inbound/web/dto/request/UpdateAccountInfoRequest.kt
+++ b/src/main/kotlin/sharev/account/adapter/inbound/web/dto/request/UpdateAccountInfoRequest.kt
@@ -2,6 +2,7 @@ package sharev.account.adapter.inbound.web.dto.request
 
 import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 
 data class UpdateAccountInfoRequest(
@@ -12,4 +13,10 @@ data class UpdateAccountInfoRequest(
     @field:Email
     @field:Size(max = 320)
     val email: String,
+
+    @field:NotNull
+    val addLinkUrls: Set<String>? = emptySet(),
+
+    @field:NotNull
+    val deleteLinkIds: Set<Long>? = emptySet(),
 )

--- a/src/main/kotlin/sharev/account/adapter/inbound/web/mapper/AccountWebMapper.kt
+++ b/src/main/kotlin/sharev/account/adapter/inbound/web/mapper/AccountWebMapper.kt
@@ -11,7 +11,13 @@ import sharev.account.application.port.inbound.result.UpdateAccountInfoResult
 import sharev.common.adapter.inbound.security.model.AccountPrincipal
 
 fun UpdateAccountInfoRequest.toCommand(accountId: Long) =
-    UpdateAccountInfoCommand(accountId, this.name, this.email)
+    UpdateAccountInfoCommand(
+        accountId,
+        name,
+        email,
+        requireNotNull(addLinkUrls),
+        requireNotNull(deleteLinkIds)
+    )
 
 fun UpdateAccountInfoResult.toUpdateAccountInfoResponse() =
     UpdateAccountInfoResponse(id, name, email, updateAt)
@@ -26,4 +32,4 @@ fun AccountPrincipal.toDeleteAccountCommand(feedback: String) =
     DeleteAccountCommand(id, feedback)
 
 fun AccountPrincipal.updateFrom(result: UpdateAccountInfoResult) =
-    copy(role = result.role.name, email = result.email, accountName = result.name)
+    copy(email = result.email, accountName = result.name)

--- a/src/main/kotlin/sharev/account/adapter/outbound/jpa/AccountJpaAdapter.kt
+++ b/src/main/kotlin/sharev/account/adapter/outbound/jpa/AccountJpaAdapter.kt
@@ -9,6 +9,7 @@ import sharev.account.adapter.outbound.jpa.repository.AccountRepository
 import sharev.account.application.port.outbound.DeleteAccountPort
 import sharev.account.application.port.outbound.LoadAccountPort
 import sharev.account.application.port.outbound.SaveAccountPort
+import sharev.account.application.port.outbound.UpdateAccountPort
 import sharev.account.domain.exception.AccountException
 import sharev.account.domain.exception.AccountExceptionCode
 import sharev.account.domain.model.Account
@@ -16,7 +17,7 @@ import sharev.account.domain.model.Account
 @Component
 class AccountJpaAdapter(
     private val accountRepository: AccountRepository
-) : LoadAccountPort, SaveAccountPort, DeleteAccountPort {
+) : LoadAccountPort, SaveAccountPort, DeleteAccountPort, UpdateAccountPort {
 
     override fun load(accountId: Long): Account {
         val accountJpaEntity = accountRepository.findByIdOrNull(accountId)
@@ -37,6 +38,16 @@ class AccountJpaAdapter(
 
         return accountRepository.save(accountJpaEntity)
             .toDomainModel()
+    }
+
+    override fun update(accountId: Long, name: String, email: String): Account {
+        val accountJpaEntity = accountRepository.findByIdOrNull(accountId)
+            ?: throw AccountException(AccountExceptionCode.ACCOUNT_NOT_FOUND)
+
+        accountJpaEntity.name = name
+        accountJpaEntity.email = email
+
+        return accountJpaEntity.toDomainModel()
     }
 
     override fun delete(accountId: Long) {

--- a/src/main/kotlin/sharev/account/application/port/inbound/command/UpdateAccountInfoCommand.kt
+++ b/src/main/kotlin/sharev/account/application/port/inbound/command/UpdateAccountInfoCommand.kt
@@ -4,5 +4,7 @@ data class UpdateAccountInfoCommand(
     val accountId: Long,
     val name: String,
     val email: String,
+    val addLinkUrls: Set<String>,
+    val deleteLinkIds: Set<Long>,
 ) {
 }

--- a/src/main/kotlin/sharev/account/application/port/inbound/mapper/AccountInboundMapper.kt
+++ b/src/main/kotlin/sharev/account/application/port/inbound/mapper/AccountInboundMapper.kt
@@ -3,4 +3,4 @@ package sharev.account.application.port.inbound.mapper
 import sharev.account.application.port.inbound.result.UpdateAccountInfoResult
 import sharev.account.domain.model.Account
 
-fun Account.toUpdateAccountInfoResult() = UpdateAccountInfoResult(id, name, email, role)
+fun Account.toUpdateAccountInfoResult() = UpdateAccountInfoResult(id, name, email)

--- a/src/main/kotlin/sharev/account/application/port/inbound/result/UpdateAccountInfoResult.kt
+++ b/src/main/kotlin/sharev/account/application/port/inbound/result/UpdateAccountInfoResult.kt
@@ -1,13 +1,11 @@
 package sharev.account.application.port.inbound.result
 
-import sharev.account.domain.model.AccountRole
 import java.time.LocalDateTime
 
 data class UpdateAccountInfoResult(
     val id: Long,
     val name: String,
     val email: String,
-    val role: AccountRole,
     val updateAt: LocalDateTime = LocalDateTime.now()
 ) {
 }

--- a/src/main/kotlin/sharev/account/application/port/outbound/UpdateAccountPort.kt
+++ b/src/main/kotlin/sharev/account/application/port/outbound/UpdateAccountPort.kt
@@ -1,0 +1,7 @@
+package sharev.account.application.port.outbound
+
+import sharev.account.domain.model.Account
+
+fun interface UpdateAccountPort {
+    fun update(accountId: Long, name: String, email: String): Account
+}

--- a/src/main/kotlin/sharev/account/application/service/AccountService.kt
+++ b/src/main/kotlin/sharev/account/application/service/AccountService.kt
@@ -10,17 +10,16 @@ import sharev.account.application.port.inbound.result.UpdateAccountInfoResult
 import sharev.account.application.port.inbound.usecase.DeleteAccountUseCase
 import sharev.account.application.port.inbound.usecase.UpdateAccountInfoUseCase
 import sharev.account.application.port.outbound.DeleteAccountPort
-import sharev.account.application.port.outbound.LoadAccountPort
-import sharev.account.application.port.outbound.SaveAccountPort
+import sharev.account.application.port.outbound.UpdateAccountPort
+import sharev.account.domain.event.AccountLinkUpdatedEvent
 import sharev.account.domain.event.AccountWithdrawalFeedbackSubmittedEvent
 import sharev.common.application.port.outbound.PublishEventPort
 
 @Service
 @Transactional(readOnly = true)
 class AccountService(
-    private val loadAccountPort: LoadAccountPort,
+    private val updateAccountPort: UpdateAccountPort,
     private val deleteAccountPort: DeleteAccountPort,
-    private val saveAccountPort: SaveAccountPort,
     private val publishEventPort: PublishEventPort,
 ) : UpdateAccountInfoUseCase, DeleteAccountUseCase {
 
@@ -28,10 +27,17 @@ class AccountService(
     override fun updateAccountInfo(
         command: UpdateAccountInfoCommand
     ): UpdateAccountInfoResult {
-        val account = loadAccountPort.load(command.accountId)
-        val updatedAccount = account.updateInfo(command.name, command.email)
-        return saveAccountPort.save(updatedAccount)
-            .toUpdateAccountInfoResult()
+        val account = updateAccountPort.update(command.accountId, command.name, command.email)
+
+        publishEventPort.publish(
+            AccountLinkUpdatedEvent(
+                accountId = command.accountId,
+                addLinkUrls = command.addLinkUrls,
+                deleteLinkIds = command.deleteLinkIds,
+            )
+        )
+
+        return account.toUpdateAccountInfoResult()
     }
 
     @Transactional

--- a/src/main/kotlin/sharev/account/domain/event/AccountLinkUpdatedEvent.kt
+++ b/src/main/kotlin/sharev/account/domain/event/AccountLinkUpdatedEvent.kt
@@ -1,0 +1,7 @@
+package sharev.account.domain.event
+
+data class AccountLinkUpdatedEvent(
+    val accountId: Long,
+    val addLinkUrls: Set<String>,
+    val deleteLinkIds: Set<Long>,
+)

--- a/src/main/kotlin/sharev/card/adapter/outbound/jpa/entity/CardJpaEntity.kt
+++ b/src/main/kotlin/sharev/card/adapter/outbound/jpa/entity/CardJpaEntity.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.*
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import sharev.account.adapter.outbound.jpa.entity.AccountJpaEntity
+import sharev.common.adapter.outbound.jpa.entity.BaseTimeEntity
 import sharev.gathering.adapter.outbound.jpa.entity.GatheringJpaEntity
 
 @Entity
@@ -32,7 +33,7 @@ class CardJpaEntity(
     @Column
     @JdbcTypeCode(SqlTypes.JSON)
     var introductionText: Map<String, String>? = null,
-) : sharev.common.adapter.outbound.jpa.entity.BaseTimeEntity() {
+) : BaseTimeEntity() {
 
     fun updateIntroductionText(templateVersion: Int, introductionText: Map<String, String>) {
         this.templateVersion = templateVersion

--- a/src/main/kotlin/sharev/card/adapter/outbound/jpa/repository/CardRepository.kt
+++ b/src/main/kotlin/sharev/card/adapter/outbound/jpa/repository/CardRepository.kt
@@ -6,7 +6,7 @@ import sharev.card.adapter.outbound.jpa.entity.CardJpaEntity
 import java.util.*
 
 interface CardRepository : JpaRepository<CardJpaEntity, Long>,
-    sharev.card.adapter.outbound.jpa.repository.CardRepositoryCustom {
+    CardRepositoryCustom {
     fun findByGatheringIdAndAccountId(gatheringId: UUID, accountId: Long): CardJpaEntity?
 
     fun findByGatheringIdAndPinNumber(gatheringId: UUID, pinNumber: Int): CardJpaEntity?

--- a/src/main/kotlin/sharev/card/domain/exception/CardException.kt
+++ b/src/main/kotlin/sharev/card/domain/exception/CardException.kt
@@ -3,8 +3,8 @@ package sharev.card.domain.exception
 import sharev.common.domain.exception.BusinessException
 
 class CardException : BusinessException {
-    constructor(code: sharev.card.domain.exception.CardExceptionCode) : super(code.toDetails())
-    constructor(code: sharev.card.domain.exception.CardExceptionCode, message: String) : super(
+    constructor(code: CardExceptionCode) : super(code.toDetails())
+    constructor(code: CardExceptionCode, message: String) : super(
         code.toDetails().copy(message = message)
     )
 }

--- a/src/main/kotlin/sharev/connection/adapter/inbound/event/ShowCardEventListener.kt
+++ b/src/main/kotlin/sharev/connection/adapter/inbound/event/ShowCardEventListener.kt
@@ -5,10 +5,12 @@ import org.springframework.context.event.EventListener
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import sharev.card.domain.event.ShowCardEvent
+import sharev.connection.application.port.inbound.command.ConnectCardsCommand
+import sharev.connection.application.port.inbound.usecase.ConnectCardsUseCase
 
 @Component
 class ShowCardEventListener(
-    private val connectCardsUseCase: sharev.connection.application.port.inbound.usecase.ConnectCardsUseCase,
+    private val connectCardsUseCase: ConnectCardsUseCase,
 ) {
     private val log = LoggerFactory.getLogger(javaClass)
 
@@ -17,7 +19,7 @@ class ShowCardEventListener(
     fun connect(showCardEvent: ShowCardEvent) {
         try {
             connectCardsUseCase.connect(
-                _root_ide_package_.sharev.connection.application.port.inbound.command.ConnectCardsCommand(
+                ConnectCardsCommand(
                     gatheringId = showCardEvent.eventId,
                     accountId = showCardEvent.accountId,
                     targetCardId = showCardEvent.targetCardId,

--- a/src/main/kotlin/sharev/connection/adapter/outbound/jpa/ConnectionJpaAdapter.kt
+++ b/src/main/kotlin/sharev/connection/adapter/outbound/jpa/ConnectionJpaAdapter.kt
@@ -5,12 +5,15 @@ import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import sharev.card.adapter.outbound.jpa.repository.CardRepository
 import sharev.card.domain.exception.CardException
+import sharev.connection.adapter.outbound.jpa.entity.ConnectionJpaEntity
+import sharev.connection.adapter.outbound.jpa.repository.ConnectionRepository
+import sharev.connection.domain.exception.ConnectionException
 import sharev.card.domain.exception.CardExceptionCode as CardCode
 import sharev.connection.domain.exception.ConnectionExceptionCode as ConnectionCode
 
 @Component
 class ConnectionJpaAdapter(
-    private val connectionRepository: sharev.connection.adapter.outbound.jpa.repository.ConnectionRepository,
+    private val connectionRepository: ConnectionRepository,
     private val cardRepository: CardRepository,
 ) : sharev.connection.application.port.outbound.SaveConnectionPort {
 
@@ -22,13 +25,13 @@ class ConnectionJpaAdapter(
 
         try {
             connectionRepository.saveAllAndFlush(
-                _root_ide_package_.sharev.connection.adapter.outbound.jpa.entity.ConnectionJpaEntity.connect(
+                ConnectionJpaEntity.connect(
                     myCard,
                     otherCard
                 )
             )
         } catch (e: DataIntegrityViolationException) {
-            throw _root_ide_package_.sharev.connection.domain.exception.ConnectionException(ConnectionCode.REGISTER_ALREADY)
+            throw ConnectionException(ConnectionCode.REGISTER_ALREADY)
         }
     }
 }

--- a/src/main/kotlin/sharev/connection/adapter/outbound/jpa/entity/ConnectionJpaEntity.kt
+++ b/src/main/kotlin/sharev/connection/adapter/outbound/jpa/entity/ConnectionJpaEntity.kt
@@ -6,6 +6,7 @@ import org.hibernate.type.SqlTypes
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
 import sharev.card.adapter.outbound.jpa.entity.CardJpaEntity
 import sharev.common.adapter.outbound.jpa.entity.BaseTimeEntity
+import sharev.connection.domain.model.ConnectionStatusType
 
 @Entity
 @Table(name = "connections")
@@ -28,7 +29,7 @@ class ConnectionJpaEntity(
     @Column(columnDefinition = "card_connection_status")
     @Enumerated(EnumType.STRING)
     @JdbcTypeCode(SqlTypes.NAMED_ENUM)
-    val status: sharev.connection.domain.model.ConnectionStatusType = _root_ide_package_.sharev.connection.domain.model.ConnectionStatusType.REGISTRATION,
+    val status: ConnectionStatusType = ConnectionStatusType.REGISTRATION,
 
     @Column
     val memo: String? = null,

--- a/src/main/kotlin/sharev/connection/application/port/inbound/usecase/ConnectCardsUseCase.kt
+++ b/src/main/kotlin/sharev/connection/application/port/inbound/usecase/ConnectCardsUseCase.kt
@@ -1,5 +1,7 @@
 package sharev.connection.application.port.inbound.usecase
 
+import sharev.connection.application.port.inbound.command.ConnectCardsCommand
+
 fun interface ConnectCardsUseCase {
-    fun connect(command: sharev.connection.application.port.inbound.command.ConnectCardsCommand)
+    fun connect(command: ConnectCardsCommand)
 }

--- a/src/main/kotlin/sharev/connection/application/service/ConnectionService.kt
+++ b/src/main/kotlin/sharev/connection/application/service/ConnectionService.kt
@@ -4,6 +4,10 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import sharev.card.application.port.outbound.LoadCardPort
 import sharev.card.domain.exception.CardException
+import sharev.connection.application.port.inbound.command.ConnectCardsCommand
+import sharev.connection.application.port.inbound.usecase.ConnectCardsUseCase
+import sharev.connection.application.port.outbound.SaveConnectionPort
+import sharev.connection.domain.exception.ConnectionException
 import sharev.card.domain.exception.CardExceptionCode as CardCode
 import sharev.connection.domain.exception.ConnectionExceptionCode as ConnectionCode
 
@@ -11,11 +15,11 @@ import sharev.connection.domain.exception.ConnectionExceptionCode as ConnectionC
 @Transactional(readOnly = true)
 class ConnectionService(
     private val loadCardPort: LoadCardPort,
-    private val saveConnectionPort: sharev.connection.application.port.outbound.SaveConnectionPort,
-) : sharev.connection.application.port.inbound.usecase.ConnectCardsUseCase {
+    private val saveConnectionPort: SaveConnectionPort,
+) : ConnectCardsUseCase {
 
     @Transactional
-    override fun connect(command: sharev.connection.application.port.inbound.command.ConnectCardsCommand) {
+    override fun connect(command: ConnectCardsCommand) {
         val card = loadCardPort.loadByGatheringAndAccount(command.gatheringId, command.accountId)
         val targetCard = loadCardPort.load(command.targetCardId)
 
@@ -24,7 +28,7 @@ class ConnectionService(
         }
 
         if (card.id == targetCard.id) {
-            throw _root_ide_package_.sharev.connection.domain.exception.ConnectionException(ConnectionCode.REGISTER_MYSELF)
+            throw ConnectionException(ConnectionCode.REGISTER_MYSELF)
         }
 
         saveConnectionPort.save(card.id, targetCard.id)

--- a/src/main/kotlin/sharev/connection/domain/exception/ConnectionException.kt
+++ b/src/main/kotlin/sharev/connection/domain/exception/ConnectionException.kt
@@ -3,9 +3,9 @@ package sharev.connection.domain.exception
 import sharev.common.domain.exception.BusinessException
 
 class ConnectionException : BusinessException {
-    constructor(code: sharev.connection.domain.exception.ConnectionExceptionCode) : super(code.toDetails())
+    constructor(code: ConnectionExceptionCode) : super(code.toDetails())
     constructor(
-        code: sharev.connection.domain.exception.ConnectionExceptionCode,
+        code: ConnectionExceptionCode,
         message: String
     ) : super(code.toDetails().copy(message = message))
 }

--- a/src/main/kotlin/sharev/feedback/adapter/inbound/event/FeedbackEventListener.kt
+++ b/src/main/kotlin/sharev/feedback/adapter/inbound/event/FeedbackEventListener.kt
@@ -6,10 +6,11 @@ import org.springframework.transaction.event.TransactionPhase
 import org.springframework.transaction.event.TransactionalEventListener
 import sharev.account.domain.event.AccountWithdrawalFeedbackSubmittedEvent
 import sharev.feedback.application.port.inbound.command.SaveFeedbackCommand
+import sharev.feedback.application.port.inbound.usecase.SaveFeedbackUseCase
 
 @Component
 class FeedbackEventListener(
-    private val saveFeedbackUseCase: sharev.feedback.application.port.inbound.usecase.SaveFeedbackUseCase,
+    private val saveFeedbackUseCase: SaveFeedbackUseCase,
 ) {
 
     @Async

--- a/src/main/kotlin/sharev/feedback/adapter/outbound/jpa/FeedbackJpaAdapter.kt
+++ b/src/main/kotlin/sharev/feedback/adapter/outbound/jpa/FeedbackJpaAdapter.kt
@@ -2,11 +2,13 @@ package sharev.feedback.adapter.outbound.jpa
 
 import org.springframework.stereotype.Component
 import sharev.feedback.adapter.outbound.jpa.entity.FeedbackJpaEntity
+import sharev.feedback.adapter.outbound.jpa.repository.FeedbackRepository
+import sharev.feedback.application.port.outbound.SaveFeedbackPort
 
 @Component
 class FeedbackJpaAdapter(
-    private val feedbackRepository: sharev.feedback.adapter.outbound.jpa.repository.FeedbackRepository
-) : sharev.feedback.application.port.outbound.SaveFeedbackPort {
+    private val feedbackRepository: FeedbackRepository
+) : SaveFeedbackPort {
 
     override fun save(content: String) {
         feedbackRepository.save(

--- a/src/main/kotlin/sharev/feedback/application/port/inbound/usecase/SaveFeedbackUseCase.kt
+++ b/src/main/kotlin/sharev/feedback/application/port/inbound/usecase/SaveFeedbackUseCase.kt
@@ -1,5 +1,7 @@
 package sharev.feedback.application.port.inbound.usecase
 
+import sharev.feedback.application.port.inbound.command.SaveFeedbackCommand
+
 fun interface SaveFeedbackUseCase {
-    fun save(command: sharev.feedback.application.port.inbound.command.SaveFeedbackCommand)
+    fun save(command: SaveFeedbackCommand)
 }

--- a/src/main/kotlin/sharev/feedback/application/service/FeedbackService.kt
+++ b/src/main/kotlin/sharev/feedback/application/service/FeedbackService.kt
@@ -2,15 +2,18 @@ package sharev.feedback.application.service
 
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
+import sharev.feedback.application.port.inbound.command.SaveFeedbackCommand
+import sharev.feedback.application.port.inbound.usecase.SaveFeedbackUseCase
+import sharev.feedback.application.port.outbound.SaveFeedbackPort
 
 @Service
 @Transactional(readOnly = true)
 class FeedbackService(
-    private val saveFeedbackPort: sharev.feedback.application.port.outbound.SaveFeedbackPort
-) : sharev.feedback.application.port.inbound.usecase.SaveFeedbackUseCase {
+    private val saveFeedbackPort: SaveFeedbackPort
+) : SaveFeedbackUseCase {
 
     @Transactional
-    override fun save(command: sharev.feedback.application.port.inbound.command.SaveFeedbackCommand) {
+    override fun save(command: SaveFeedbackCommand) {
         saveFeedbackPort.save(command.feedback)
     }
 }

--- a/src/main/kotlin/sharev/gathering/domain/exception/GatheringException.kt
+++ b/src/main/kotlin/sharev/gathering/domain/exception/GatheringException.kt
@@ -3,9 +3,9 @@ package sharev.gathering.domain.exception
 import sharev.common.domain.exception.BusinessException
 
 class GatheringException : BusinessException {
-    constructor(code: sharev.gathering.domain.exception.GatheringExceptionCode) : super(code.toDetails())
+    constructor(code: GatheringExceptionCode) : super(code.toDetails())
     constructor(
-        code: sharev.gathering.domain.exception.GatheringExceptionCode,
+        code: GatheringExceptionCode,
         message: String
     ) : super(code.toDetails().copy(message = message))
 }

--- a/src/main/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListener.kt
+++ b/src/main/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListener.kt
@@ -1,0 +1,25 @@
+package sharev.link.adapter.inbound.event
+
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import sharev.account.domain.event.AccountLinkUpdatedEvent
+import sharev.link.application.port.outbound.DeleteLinkPort
+import sharev.link.application.port.outbound.SaveLinkPort
+
+@Component
+class AccountLinkUpdatedEventListener(
+    private val saveLinkPort: SaveLinkPort,
+    private val deleteLinkPort: DeleteLinkPort,
+) {
+
+    @EventListener
+    fun handle(event: AccountLinkUpdatedEvent) {
+        if (event.addLinkUrls.isNotEmpty()) {
+            saveLinkPort.saveAll(event.accountId, event.addLinkUrls)
+        }
+
+        if (event.deleteLinkIds.isNotEmpty()) {
+            deleteLinkPort.deleteAllByIds(event.accountId, event.deleteLinkIds)
+        }
+    }
+}

--- a/src/main/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListener.kt
+++ b/src/main/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListener.kt
@@ -14,12 +14,12 @@ class AccountLinkUpdatedEventListener(
 
     @EventListener
     fun handle(event: AccountLinkUpdatedEvent) {
-        if (event.addLinkUrls.isNotEmpty()) {
-            saveLinkPort.saveAll(event.accountId, event.addLinkUrls)
-        }
-
         if (event.deleteLinkIds.isNotEmpty()) {
             deleteLinkPort.deleteAllByIds(event.accountId, event.deleteLinkIds)
+        }
+
+        if (event.addLinkUrls.isNotEmpty()) {
+            saveLinkPort.saveAll(event.accountId, event.addLinkUrls)
         }
     }
 }

--- a/src/main/kotlin/sharev/link/adapter/outbound/jpa/LinkJpaAdapter.kt
+++ b/src/main/kotlin/sharev/link/adapter/outbound/jpa/LinkJpaAdapter.kt
@@ -33,6 +33,12 @@ class LinkJpaAdapter(
         val account = accountRepository.findByIdOrNull(accountId)
             ?: throw AccountException(AccountExceptionCode.ACCOUNT_NOT_FOUND)
 
+        val currentCount = linkRepository.countByAccountId(accountId)
+
+        if (currentCount + urls.size > Link.MAX_COUNT) {
+            throw LinkException(LinkExceptionCode.LINK_LIMIT_EXCEEDED)
+        }
+
         val entities = urls.map { LinkJpaEntity(account = account, linkUrl = it) }
         linkRepository.saveAll(entities)
     }

--- a/src/main/kotlin/sharev/link/adapter/outbound/jpa/LinkJpaAdapter.kt
+++ b/src/main/kotlin/sharev/link/adapter/outbound/jpa/LinkJpaAdapter.kt
@@ -29,6 +29,14 @@ class LinkJpaAdapter(
             .toDomainModel()
     }
 
+    override fun saveAll(accountId: Long, urls: Set<String>) {
+        val account = accountRepository.findByIdOrNull(accountId)
+            ?: throw AccountException(AccountExceptionCode.ACCOUNT_NOT_FOUND)
+
+        val entities = urls.map { LinkJpaEntity(account = account, linkUrl = it) }
+        linkRepository.saveAll(entities)
+    }
+
     override fun load(linkId: Long): Link {
         return linkRepository.findByIdOrNull(linkId)
             ?.toDomainModel()
@@ -47,5 +55,17 @@ class LinkJpaAdapter(
 
     override fun delete(linkId: Long) {
         linkRepository.deleteById(linkId)
+    }
+
+    override fun deleteAllByIds(accountId: Long, linkIds: Set<Long>) {
+        val links = linkRepository.findAllById(linkIds)
+
+        val hasOwnershipMismatch = links.any { it.account.id != accountId }
+
+        if (hasOwnershipMismatch) {
+            throw LinkException(LinkExceptionCode.LINK_OWNERSHIP_MISMATCH)
+        }
+
+        linkRepository.deleteAllInBatch(links)
     }
 }

--- a/src/main/kotlin/sharev/link/adapter/outbound/jpa/repository/LinkRepository.kt
+++ b/src/main/kotlin/sharev/link/adapter/outbound/jpa/repository/LinkRepository.kt
@@ -7,4 +7,6 @@ interface LinkRepository : JpaRepository<LinkJpaEntity, Long> {
     fun findAllByAccountIdIn(accountIds: Collection<Long>): List<LinkJpaEntity>
 
     fun findAllByAccountId(accountId: Long): List<LinkJpaEntity>
+
+    fun countByAccountId(accountId: Long): Long
 }

--- a/src/main/kotlin/sharev/link/application/port/outbound/DeleteLinkPort.kt
+++ b/src/main/kotlin/sharev/link/application/port/outbound/DeleteLinkPort.kt
@@ -1,5 +1,6 @@
 package sharev.link.application.port.outbound
 
-fun interface DeleteLinkPort {
+interface DeleteLinkPort {
     fun delete(linkId: Long)
+    fun deleteAllByIds(accountId: Long, linkIds: Set<Long>)
 }

--- a/src/main/kotlin/sharev/link/application/port/outbound/SaveLinkPort.kt
+++ b/src/main/kotlin/sharev/link/application/port/outbound/SaveLinkPort.kt
@@ -2,6 +2,7 @@ package sharev.link.application.port.outbound
 
 import sharev.link.domain.model.Link
 
-fun interface SaveLinkPort {
+interface SaveLinkPort {
     fun save(accountId: Long, url: String): Link
+    fun saveAll(accountId: Long, urls: Set<String>)
 }

--- a/src/main/kotlin/sharev/link/domain/exception/LinkExceptionCode.kt
+++ b/src/main/kotlin/sharev/link/domain/exception/LinkExceptionCode.kt
@@ -2,6 +2,7 @@ package sharev.link.domain.exception
 
 import sharev.common.domain.exception.ExceptionCategory
 import sharev.common.domain.exception.ExceptionCode
+import sharev.link.domain.model.Link
 
 enum class LinkExceptionCode(
     override val category: ExceptionCategory,
@@ -14,5 +15,9 @@ enum class LinkExceptionCode(
     LINK_OWNERSHIP_MISMATCH(
         ExceptionCategory.FORBIDDEN,
         "링크의 소유자가 아닙니다."
+    ),
+    LINK_LIMIT_EXCEEDED(
+        ExceptionCategory.BAD_REQUEST,
+        "링크는 최대 ${Link.MAX_COUNT}개까지 등록할 수 있습니다."
     )
 }

--- a/src/main/kotlin/sharev/link/domain/model/Link.kt
+++ b/src/main/kotlin/sharev/link/domain/model/Link.kt
@@ -4,4 +4,8 @@ data class Link(
     val id: Long,
     val accountId: Long,
     val url: String,
-)
+) {
+    companion object {
+        const val MAX_COUNT = 3
+    }
+}

--- a/src/test/kotlin/sharev/account/adapter/inbound/web/controller/AccountControllerTest.kt
+++ b/src/test/kotlin/sharev/account/adapter/inbound/web/controller/AccountControllerTest.kt
@@ -23,7 +23,6 @@ import sharev.account.application.port.inbound.command.DeleteAccountCommand
 import sharev.account.application.port.inbound.command.UpdateAccountInfoCommand
 import sharev.account.application.port.inbound.result.DeleteAccountResult
 import sharev.account.application.port.inbound.result.UpdateAccountInfoResult
-import sharev.account.domain.model.AccountRole
 import java.time.LocalDateTime
 
 class AccountControllerTest : ControllerTestSupport() {
@@ -31,11 +30,11 @@ class AccountControllerTest : ControllerTestSupport() {
     @WithCustomMockUser
     @DisplayName("회원 정보 업데이트")
     fun updateAccountInfo() {
-        val requestDto = UpdateAccountInfoRequest("김주호", "eora21@naver.com")
-        val command = UpdateAccountInfoCommand(1L, "김주호", "eora21@naver.com")
+        val requestDto = UpdateAccountInfoRequest("김주호", "eora21@naver.com", setOf("https://link.com"), setOf(1L))
+        val command = UpdateAccountInfoCommand(1L, "김주호", "eora21@naver.com", setOf("https://link.com"), setOf(1L))
 
         given(updateAccountInfoUseCase.updateAccountInfo(command)).willReturn(
-            UpdateAccountInfoResult(1L, "김주호", "eora21@naver.com", AccountRole.USER, LocalDateTime.now())
+            UpdateAccountInfoResult(1L, "김주호", "eora21@naver.com")
         )
 
         val request = RestDocumentationRequestBuilders.patch("/accounts")
@@ -55,6 +54,8 @@ class AccountControllerTest : ControllerTestSupport() {
                             .requestFields(
                                 fieldWithPath("name").type(STRING).description("회원 이름"),
                                 fieldWithPath("email").type(STRING).description("이메일"),
+                                fieldWithPath("addLinkUrls[]").type(STRING).description("추가할 링크 URL 목록"),
+                                fieldWithPath("deleteLinkIds[]").type(NUMBER).description("삭제할 링크 ID 목록"),
                             )
                             .responseFields(
                                 fieldWithPath("id").type(NUMBER).description("회원 ID"),

--- a/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
+++ b/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
@@ -1,6 +1,7 @@
 package sharev.account.application.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -32,7 +33,8 @@ class AccountServiceTest {
     // ───────────── updateAccountInfo ─────────────
 
     @Test
-    fun `정상 수정 시 updateAccountInfo는 업데이트된 계정 정보를 반환한다`() {
+    @DisplayName("정상 수정 시 updateAccountInfo는 업데이트된 계정 정보를 반환한다")
+    fun updateAccountInfo_returnsUpdatedInfo() {
         val accountId = 10L
         val command = UpdateAccountInfoCommand(
             accountId = accountId,
@@ -54,7 +56,8 @@ class AccountServiceTest {
     }
 
     @Test
-    fun `updateAccountInfo는 링크 변경 이벤트를 발행한다`() {
+    @DisplayName("updateAccountInfo는 링크 변경 이벤트를 발행한다")
+    fun updateAccountInfo_publishesLinkUpdatedEvent() {
         val accountId = 10L
         val addLinkUrls = setOf("https://link1.com", "https://link2.com")
         val deleteLinkIds = setOf(3L, 4L)
@@ -82,7 +85,8 @@ class AccountServiceTest {
     // ───────────── delete ─────────────
 
     @Test
-    fun `피드백이 blank이면 delete 시 이벤트를 발행하지 않는다`() {
+    @DisplayName("피드백이 blank이면 delete 시 이벤트를 발행하지 않는다")
+    fun delete_doesNotPublishEvent_whenFeedbackIsBlank() {
         val accountId = 10L
         val command = DeleteAccountCommand(accountId = accountId, feedback = "  ")
 
@@ -94,7 +98,8 @@ class AccountServiceTest {
     }
 
     @Test
-    fun `피드백이 non-blank이면 delete 시 이벤트를 발행한다`() {
+    @DisplayName("피드백이 non-blank이면 delete 시 이벤트를 발행한다")
+    fun delete_publishesFeedbackEvent_whenFeedbackIsNonBlank() {
         val accountId = 10L
         val feedback = "서비스가 불편했습니다"
         val command = DeleteAccountCommand(accountId = accountId, feedback = feedback)
@@ -111,7 +116,8 @@ class AccountServiceTest {
     }
 
     @Test
-    fun `정상 삭제 시 delete는 deleteAccountPort를 호출하고 accountId를 반환한다`() {
+    @DisplayName("정상 삭제 시 delete는 deleteAccountPort를 호출하고 accountId를 반환한다")
+    fun delete_callsDeletePortAndReturnsAccountId() {
         val accountId = 10L
         val command = DeleteAccountCommand(accountId = accountId, feedback = "")
 

--- a/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
+++ b/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
@@ -11,23 +11,21 @@ import org.mockito.kotlin.argumentCaptor
 import sharev.account.application.port.inbound.command.DeleteAccountCommand
 import sharev.account.application.port.inbound.command.UpdateAccountInfoCommand
 import sharev.account.application.port.outbound.DeleteAccountPort
-import sharev.account.application.port.outbound.LoadAccountPort
-import sharev.account.application.port.outbound.SaveAccountPort
+import sharev.account.application.port.outbound.UpdateAccountPort
+import sharev.account.domain.event.AccountLinkUpdatedEvent
 import sharev.account.domain.event.AccountWithdrawalFeedbackSubmittedEvent
 import sharev.account.domain.model.Account
 import sharev.account.domain.model.AccountRole
 import sharev.common.application.port.outbound.PublishEventPort
 
 class AccountServiceTest {
-    private val loadAccountPort = mock(LoadAccountPort::class.java)
+    private val updateAccountPort = mock(UpdateAccountPort::class.java)
     private val deleteAccountPort = mock(DeleteAccountPort::class.java)
-    private val saveAccountPort = mock(SaveAccountPort::class.java)
     private val publishEventPort = mock(PublishEventPort::class.java)
 
     private val accountService = AccountService(
-        loadAccountPort,
+        updateAccountPort,
         deleteAccountPort,
-        saveAccountPort,
         publishEventPort,
     )
 
@@ -36,19 +34,49 @@ class AccountServiceTest {
     @Test
     fun `정상 수정 시 updateAccountInfo는 업데이트된 계정 정보를 반환한다`() {
         val accountId = 10L
-        val command = UpdateAccountInfoCommand(accountId = accountId, name = "새이름", email = "new@test.com")
-        val existingAccount = account(id = accountId, name = "기존이름", email = "old@test.com")
+        val command = UpdateAccountInfoCommand(
+            accountId = accountId,
+            name = "새이름",
+            email = "new@test.com",
+            addLinkUrls = setOf("https://new-link.com"),
+            deleteLinkIds = setOf(1L, 2L),
+        )
         val updatedAccount = account(id = accountId, name = "새이름", email = "new@test.com")
 
-        given(loadAccountPort.load(accountId)).willReturn(existingAccount)
-        given(saveAccountPort.save(updatedAccount)).willReturn(updatedAccount)
+        given(updateAccountPort.update(accountId, "새이름", "new@test.com")).willReturn(updatedAccount)
 
         val result = accountService.updateAccountInfo(command)
 
         assertThat(result.id).isEqualTo(accountId)
         assertThat(result.name).isEqualTo("새이름")
         assertThat(result.email).isEqualTo("new@test.com")
-        then(saveAccountPort).should().save(updatedAccount)
+        then(updateAccountPort).should().update(accountId, "새이름", "new@test.com")
+    }
+
+    @Test
+    fun `updateAccountInfo는 링크 변경 이벤트를 발행한다`() {
+        val accountId = 10L
+        val addLinkUrls = setOf("https://link1.com", "https://link2.com")
+        val deleteLinkIds = setOf(3L, 4L)
+        val command = UpdateAccountInfoCommand(
+            accountId = accountId,
+            name = "이름",
+            email = "email@test.com",
+            addLinkUrls = addLinkUrls,
+            deleteLinkIds = deleteLinkIds,
+        )
+        val updatedAccount = account(id = accountId, name = "이름", email = "email@test.com")
+        val eventCaptor = argumentCaptor<Any>()
+
+        given(updateAccountPort.update(accountId, "이름", "email@test.com")).willReturn(updatedAccount)
+
+        accountService.updateAccountInfo(command)
+
+        then(publishEventPort).should().publish(eventCaptor.capture())
+        val capturedEvent = eventCaptor.firstValue as AccountLinkUpdatedEvent
+        assertThat(capturedEvent.accountId).isEqualTo(accountId)
+        assertThat(capturedEvent.addLinkUrls).isEqualTo(addLinkUrls)
+        assertThat(capturedEvent.deleteLinkIds).isEqualTo(deleteLinkIds)
     }
 
     // ───────────── delete ─────────────

--- a/src/test/kotlin/sharev/account/application/service/OAuthAccountServiceTest.kt
+++ b/src/test/kotlin/sharev/account/application/service/OAuthAccountServiceTest.kt
@@ -1,6 +1,7 @@
 package sharev.account.application.service
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -33,7 +34,8 @@ class OAuthAccountServiceTest {
     // ───────────── login ─────────────
 
     @Test
-    fun `기존 OAuth 계정이면 login 시 기존 account를 반환한다`() {
+    @DisplayName("기존 OAuth 계정이면 login 시 기존 account를 반환한다")
+    fun login_returnsExistingAccount_whenOAuthAccountExists() {
         val accountId = 10L
         val provider = OAuthProvider.KAKAO
         val subjectIdentifier = "kakao-subject-001"
@@ -65,7 +67,8 @@ class OAuthAccountServiceTest {
     }
 
     @Test
-    fun `신규 사용자면 login 시 account를 저장하고 OAuthAccount를 저장한다`() {
+    @DisplayName("신규 사용자면 login 시 account를 저장하고 OAuthAccount를 저장한다")
+    fun login_savesAccountAndOAuthAccount_whenNewUser() {
         val provider = OAuthProvider.KAKAO
         val subjectIdentifier = "kakao-subject-new"
         val command = OAuthLoginCommand(

--- a/src/test/kotlin/sharev/connection/application/service/ConnectionServiceTest.kt
+++ b/src/test/kotlin/sharev/connection/application/service/ConnectionServiceTest.kt
@@ -1,6 +1,7 @@
 package sharev.connection.application.service
 
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -18,7 +19,8 @@ class ConnectionServiceTest {
     private val connectionService = ConnectionService(loadCardPort, saveConnectionPort)
 
     @Test
-    fun `같은 행사에 속하지 않은 카드는 연결할 수 없다`() {
+    @DisplayName("같은 행사에 속하지 않은 카드는 연결할 수 없다")
+    fun connect_throwsException_whenCardsInDifferentGatherings() {
         val gatheringId = UUID.randomUUID()
         val otherGatheringId = UUID.randomUUID()
         val myCard = card(id = 1L, gatheringId = gatheringId, accountId = 1L)

--- a/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
+++ b/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
@@ -2,6 +2,7 @@ package sharev.gathering.application.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -45,7 +46,8 @@ class GatheringParticipantServiceTest {
     // ───────────── create ─────────────
 
     @Test
-    fun `admin이 아니면 create 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 create 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun create_throwsException_whenNotAdmin() {
         val command = createGatheringCommand()
 
         given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(false)
@@ -61,7 +63,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `admin이면 create 시 gathering을 저장하고 결과를 반환한다`() {
+    @DisplayName("admin이면 create 시 gathering을 저장하고 결과를 반환한다")
+    fun create_savesGathering_whenAdmin() {
         val command = createGatheringCommand()
         val savedGathering = gathering(id = UUID.randomUUID(), command = command)
 
@@ -78,7 +81,8 @@ class GatheringParticipantServiceTest {
     // ───────────── getGatherings ─────────────
 
     @Test
-    fun `팀 멤버가 아니면 getGatherings 시 NOT_TEAM_MEMBER 예외가 발생한다`() {
+    @DisplayName("팀 멤버가 아니면 getGatherings 시 NOT_TEAM_MEMBER 예외가 발생한다")
+    fun getGatherings_throwsException_whenNotTeamMember() {
         val accountId = 1L
         val teamId = 2L
 
@@ -95,7 +99,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `팀 멤버이면 getGatherings 시 행사 목록을 반환한다`() {
+    @DisplayName("팀 멤버이면 getGatherings 시 행사 목록을 반환한다")
+    fun getGatherings_returnsGatheringList_whenTeamMember() {
         val accountId = 1L
         val teamId = 2L
         val gatheringList = listOf(
@@ -116,7 +121,8 @@ class GatheringParticipantServiceTest {
     // ───────────── getGathering (getDetail) ─────────────
 
     @Test
-    fun `팀 멤버가 아니면 getGathering 시 NOT_TEAM_MEMBER 예외가 발생한다`() {
+    @DisplayName("팀 멤버가 아니면 getGathering 시 NOT_TEAM_MEMBER 예외가 발생한다")
+    fun getGathering_throwsException_whenNotTeamMember() {
         val accountId = 1L
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
@@ -134,7 +140,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `gathering이 다른 팀에 속하면 getGathering 시 GATHERING_NOT_FOUND 예외가 발생한다`() {
+    @DisplayName("gathering이 다른 팀에 속하면 getGathering 시 GATHERING_NOT_FOUND 예외가 발생한다")
+    fun getGathering_throwsException_whenGatheringInDifferentTeam() {
         val accountId = 1L
         val teamId = 2L
         val otherTeamId = 99L
@@ -153,7 +160,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `정상 조회 시 getGathering은 gathering 상세 정보를 반환한다`() {
+    @DisplayName("정상 조회 시 getGathering은 gathering 상세 정보를 반환한다")
+    fun getGathering_returnsDetail() {
         val accountId = 1L
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
@@ -171,7 +179,8 @@ class GatheringParticipantServiceTest {
     // ───────────── update ─────────────
 
     @Test
-    fun `admin이 아니면 update 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 update 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun update_throwsException_whenNotAdmin() {
         val command = updateGatheringCommand()
 
         given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(false)
@@ -187,7 +196,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `admin이면 update 시 gathering을 수정하고 결과를 반환한다`() {
+    @DisplayName("admin이면 update 시 gathering을 수정하고 결과를 반환한다")
+    fun update_updatesGathering_whenAdmin() {
         val command = updateGatheringCommand()
         val updatedGathering = gathering(command.gatheringId, teamId = command.teamId, title = command.title)
         val captor = argumentCaptor<Gathering>()
@@ -219,7 +229,8 @@ class GatheringParticipantServiceTest {
     // ───────────── delete ─────────────
 
     @Test
-    fun `admin이 아니면 delete 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 delete 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun delete_throwsException_whenNotAdmin() {
         val accountId = 1L
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
@@ -237,7 +248,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `다른 팀의 행사를 삭제하려 하면 GATHERING_NOT_FOUND 예외가 발생하고 softDelete를 호출하지 않는다`() {
+    @DisplayName("다른 팀의 행사를 삭제하려 하면 GATHERING_NOT_FOUND 예외가 발생하고 softDelete를 호출하지 않는다")
+    fun delete_throwsException_whenGatheringInDifferentTeam() {
         val accountId = 1L
         val teamId = 2L
         val otherTeamId = 99L
@@ -258,7 +270,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `admin이면 delete 시 softDelete를 호출하고 gatheringId를 반환한다`() {
+    @DisplayName("admin이면 delete 시 softDelete를 호출하고 gatheringId를 반환한다")
+    fun delete_softDeletesGathering_whenAdmin() {
         val accountId = 1L
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
@@ -276,7 +289,8 @@ class GatheringParticipantServiceTest {
     // ───────────── getLatestTemplate (getIntroduceTemplate) ─────────────
 
     @Test
-    fun `참가자가 아니면 getLatestTemplate 시 GATHERING_PARTICIPANT_NOT_FOUND 예외가 발생한다`() {
+    @DisplayName("참가자가 아니면 getLatestTemplate 시 GATHERING_PARTICIPANT_NOT_FOUND 예외가 발생한다")
+    fun getLatestTemplate_throwsException_whenNotParticipant() {
         val gatheringId = UUID.randomUUID()
         val accountId = 1L
 
@@ -293,7 +307,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `참가자이면 getLatestTemplate 시 최신 템플릿을 반환한다`() {
+    @DisplayName("참가자이면 getLatestTemplate 시 최신 템플릿을 반환한다")
+    fun getLatestTemplate_returnsLatestTemplate_whenParticipant() {
         val gatheringId = UUID.randomUUID()
         val accountId = 1L
         val template = introduceTemplate(gatheringId = gatheringId)
@@ -310,7 +325,8 @@ class GatheringParticipantServiceTest {
     // ───────────── isParticipant ─────────────
 
     @Test
-    fun `isParticipant는 참가 여부를 반환한다`() {
+    @DisplayName("isParticipant는 참가 여부를 반환한다")
+    fun isParticipant_returnsTrue_whenParticipant() {
         val accountId = 1L
         val gatheringId = UUID.randomUUID()
 
@@ -322,7 +338,8 @@ class GatheringParticipantServiceTest {
     }
 
     @Test
-    fun `isParticipant는 비참가 시 false를 반환한다`() {
+    @DisplayName("isParticipant는 비참가 시 false를 반환한다")
+    fun isParticipant_returnsFalse_whenNotParticipant() {
         val accountId = 1L
         val gatheringId = UUID.randomUUID()
 

--- a/src/test/kotlin/sharev/gathering/domain/model/IntroduceTemplateContentTest.kt
+++ b/src/test/kotlin/sharev/gathering/domain/model/IntroduceTemplateContentTest.kt
@@ -1,11 +1,13 @@
 package sharev.gathering.domain.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 
 class IntroduceTemplateContentTest {
     @Test
-    fun `빈 소개 템플릿 본문은 유효하다`() {
+    @DisplayName("빈 소개 템플릿 본문은 유효하다")
+    fun emptyIntroduceTemplateContent_isValid() {
         val content = IntroduceTemplateContent("", emptyMap())
 
         assertThat(content.text).isEmpty()

--- a/src/test/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListenerTest.kt
+++ b/src/test/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListenerTest.kt
@@ -1,0 +1,81 @@
+package sharev.link.adapter.inbound.event
+
+import org.junit.jupiter.api.Test
+import org.mockito.BDDMockito.then
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.never
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import sharev.account.domain.event.AccountLinkUpdatedEvent
+import sharev.link.application.port.outbound.DeleteLinkPort
+import sharev.link.application.port.outbound.SaveLinkPort
+
+class AccountLinkUpdatedEventListenerTest {
+    private val saveLinkPort = mock(SaveLinkPort::class.java)
+    private val deleteLinkPort = mock(DeleteLinkPort::class.java)
+
+    private val listener = AccountLinkUpdatedEventListener(saveLinkPort, deleteLinkPort)
+
+    @Test
+    fun `추가 링크가 있으면 saveAll을 호출한다`() {
+        val accountId = 10L
+        val addLinkUrls = setOf("https://link1.com", "https://link2.com")
+        val event = AccountLinkUpdatedEvent(
+            accountId = accountId,
+            addLinkUrls = addLinkUrls,
+            deleteLinkIds = emptySet(),
+        )
+
+        listener.handle(event)
+
+        then(saveLinkPort).should().saveAll(accountId, addLinkUrls)
+        then(deleteLinkPort).should(never()).deleteAllByIds(any(), any())
+    }
+
+    @Test
+    fun `삭제 링크가 있으면 deleteAllByIds를 호출한다`() {
+        val accountId = 10L
+        val deleteLinkIds = setOf(1L, 2L)
+        val event = AccountLinkUpdatedEvent(
+            accountId = accountId,
+            addLinkUrls = emptySet(),
+            deleteLinkIds = deleteLinkIds,
+        )
+
+        listener.handle(event)
+
+        then(saveLinkPort).should(never()).saveAll(any(), any())
+        then(deleteLinkPort).should().deleteAllByIds(accountId, deleteLinkIds)
+    }
+
+    @Test
+    fun `추가와 삭제 링크가 모두 있으면 saveAll과 deleteAllByIds를 모두 호출한다`() {
+        val accountId = 10L
+        val addLinkUrls = setOf("https://new.com")
+        val deleteLinkIds = setOf(5L)
+        val event = AccountLinkUpdatedEvent(
+            accountId = accountId,
+            addLinkUrls = addLinkUrls,
+            deleteLinkIds = deleteLinkIds,
+        )
+
+        listener.handle(event)
+
+        then(saveLinkPort).should().saveAll(accountId, addLinkUrls)
+        then(deleteLinkPort).should().deleteAllByIds(accountId, deleteLinkIds)
+    }
+
+    @Test
+    fun `추가와 삭제 링크가 모두 비어있으면 아무 포트도 호출하지 않는다`() {
+        val event = AccountLinkUpdatedEvent(
+            accountId = 10L,
+            addLinkUrls = emptySet(),
+            deleteLinkIds = emptySet(),
+        )
+
+        listener.handle(event)
+
+        then(saveLinkPort).should(never()).saveAll(any(), any())
+        then(deleteLinkPort).should(never()).deleteAllByIds(any(), any())
+    }
+}

--- a/src/test/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListenerTest.kt
+++ b/src/test/kotlin/sharev/link/adapter/inbound/event/AccountLinkUpdatedEventListenerTest.kt
@@ -1,5 +1,6 @@
 package sharev.link.adapter.inbound.event
 
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
@@ -17,7 +18,8 @@ class AccountLinkUpdatedEventListenerTest {
     private val listener = AccountLinkUpdatedEventListener(saveLinkPort, deleteLinkPort)
 
     @Test
-    fun `추가 링크가 있으면 saveAll을 호출한다`() {
+    @DisplayName("추가 링크가 있으면 saveAll을 호출한다")
+    fun handle_callsSaveAll_whenAddLinksExist() {
         val accountId = 10L
         val addLinkUrls = setOf("https://link1.com", "https://link2.com")
         val event = AccountLinkUpdatedEvent(
@@ -33,7 +35,8 @@ class AccountLinkUpdatedEventListenerTest {
     }
 
     @Test
-    fun `삭제 링크가 있으면 deleteAllByIds를 호출한다`() {
+    @DisplayName("삭제 링크가 있으면 deleteAllByIds를 호출한다")
+    fun handle_callsDeleteAllByIds_whenDeleteLinksExist() {
         val accountId = 10L
         val deleteLinkIds = setOf(1L, 2L)
         val event = AccountLinkUpdatedEvent(
@@ -49,7 +52,8 @@ class AccountLinkUpdatedEventListenerTest {
     }
 
     @Test
-    fun `추가와 삭제 링크가 모두 있으면 saveAll과 deleteAllByIds를 모두 호출한다`() {
+    @DisplayName("추가와 삭제 링크가 모두 있으면 saveAll과 deleteAllByIds를 모두 호출한다")
+    fun handle_callsBothSaveAndDelete_whenBothExist() {
         val accountId = 10L
         val addLinkUrls = setOf("https://new.com")
         val deleteLinkIds = setOf(5L)
@@ -66,7 +70,8 @@ class AccountLinkUpdatedEventListenerTest {
     }
 
     @Test
-    fun `추가와 삭제 링크가 모두 비어있으면 아무 포트도 호출하지 않는다`() {
+    @DisplayName("추가와 삭제 링크가 모두 비어있으면 아무 포트도 호출하지 않는다")
+    fun handle_callsNoPorts_whenBothEmpty() {
         val event = AccountLinkUpdatedEvent(
             accountId = 10L,
             addLinkUrls = emptySet(),

--- a/src/test/kotlin/sharev/link/application/service/LinkServiceTest.kt
+++ b/src/test/kotlin/sharev/link/application/service/LinkServiceTest.kt
@@ -2,6 +2,7 @@ package sharev.link.application.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -31,7 +32,8 @@ class LinkServiceTest {
     // ───────────── create ─────────────
 
     @Test
-    fun `정상 생성 시 create는 저장된 링크를 반환한다`() {
+    @DisplayName("정상 생성 시 create는 저장된 링크를 반환한다")
+    fun create_returnsSavedLink() {
         val accountId = 10L
         val url = "https://example.com"
         val command = CreateLinkCommand(accountId = accountId, url = url)
@@ -49,7 +51,8 @@ class LinkServiceTest {
     // ───────────── getLinks ─────────────
 
     @Test
-    fun `정상 조회 시 getLinks는 링크 목록을 반환한다`() {
+    @DisplayName("정상 조회 시 getLinks는 링크 목록을 반환한다")
+    fun getLinks_returnsLinkList() {
         val accountId = 10L
         val command = GetLinksCommand(accountId = accountId)
         val links = listOf(
@@ -69,7 +72,8 @@ class LinkServiceTest {
     // ───────────── delete ─────────────
 
     @Test
-    fun `소유자 불일치 시 delete는 LINK_OWNERSHIP_MISMATCH 예외가 발생한다`() {
+    @DisplayName("소유자 불일치 시 delete는 LINK_OWNERSHIP_MISMATCH 예외가 발생한다")
+    fun delete_throwsOwnershipMismatch_whenNotOwner() {
         val accountId = 10L
         val otherAccountId = 99L
         val linkId = 1L
@@ -89,7 +93,8 @@ class LinkServiceTest {
     }
 
     @Test
-    fun `정상 삭제 시 delete는 deleteLinkPort를 호출하고 linkId를 반환한다`() {
+    @DisplayName("정상 삭제 시 delete는 deleteLinkPort를 호출하고 linkId를 반환한다")
+    fun delete_callsDeletePortAndReturnsLinkId() {
         val accountId = 10L
         val linkId = 1L
         val command = DeleteLinkCommand(accountId = accountId, linkId = linkId)

--- a/src/test/kotlin/sharev/member/application/service/MemberServiceTest.kt
+++ b/src/test/kotlin/sharev/member/application/service/MemberServiceTest.kt
@@ -2,6 +2,7 @@ package sharev.member.application.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -47,7 +48,8 @@ class MemberServiceTest {
     // ───────────── isAdmin ─────────────
 
     @Test
-    fun `팀이 존재하지 않으면 isAdmin은 false를 반환한다`() {
+    @DisplayName("팀이 존재하지 않으면 isAdmin은 false를 반환한다")
+    fun isAdmin_returnsFalse_whenTeamNotExists() {
         val teamId = 1L
         val accountId = 10L
 
@@ -60,7 +62,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `admin 멤버이면 isAdmin은 true를 반환한다`() {
+    @DisplayName("admin 멤버이면 isAdmin은 true를 반환한다")
+    fun isAdmin_returnsTrue_whenAdminMember() {
         val teamId = 1L
         val accountId = 10L
 
@@ -73,7 +76,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `admin이 아니면 isAdmin은 false를 반환한다`() {
+    @DisplayName("admin이 아니면 isAdmin은 false를 반환한다")
+    fun isAdmin_returnsFalse_whenNotAdmin() {
         val teamId = 1L
         val accountId = 10L
 
@@ -88,7 +92,8 @@ class MemberServiceTest {
     // ───────────── getMembers ─────────────
 
     @Test
-    fun `팀 멤버가 아니면 getMembers 시 NOT_TEAM_MEMBER 예외가 발생한다`() {
+    @DisplayName("팀 멤버가 아니면 getMembers 시 NOT_TEAM_MEMBER 예외가 발생한다")
+    fun getMembers_throwsException_whenNotTeamMember() {
         val accountId = 10L
         val teamId = 1L
         val command = GetMembersCommand(accountId = accountId, teamId = teamId)
@@ -106,7 +111,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 조회 시 getMembers는 멤버 목록을 반환한다`() {
+    @DisplayName("정상 조회 시 getMembers는 멤버 목록을 반환한다")
+    fun getMembers_returnsMemberList() {
         val accountId = 10L
         val teamId = 1L
         val command = GetMembersCommand(accountId = accountId, teamId = teamId)
@@ -128,7 +134,8 @@ class MemberServiceTest {
     // ───────────── invite ─────────────
 
     @Test
-    fun `admin이 아니면 invite 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 invite 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun invite_throwsException_whenNotAdmin() {
         val accountId = 10L
         val teamId = 1L
         val command = InviteMemberCommand(accountId = accountId, teamId = teamId, email = "target@test.com")
@@ -146,7 +153,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `이미 팀 멤버이면 invite 시 MEMBER_ALREADY_EXISTS 예외가 발생한다`() {
+    @DisplayName("이미 팀 멤버이면 invite 시 MEMBER_ALREADY_EXISTS 예외가 발생한다")
+    fun invite_throwsException_whenMemberAlreadyExists() {
         val accountId = 10L
         val teamId = 1L
         val targetAccountId = 20L
@@ -168,7 +176,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 초대 시 INVITE 상태로 멤버를 저장한다`() {
+    @DisplayName("정상 초대 시 INVITE 상태로 멤버를 저장한다")
+    fun invite_savesMemberWithInviteStatus() {
         val accountId = 10L
         val teamId = 1L
         val targetAccountId = 20L
@@ -191,7 +200,8 @@ class MemberServiceTest {
     // ───────────── acceptInvitation ─────────────
 
     @Test
-    fun `초대 상태가 아니면 acceptInvitation 시 MEMBER_NOT_INVITED 예외가 발생한다`() {
+    @DisplayName("초대 상태가 아니면 acceptInvitation 시 MEMBER_NOT_INVITED 예외가 발생한다")
+    fun acceptInvitation_throwsException_whenNotInvited() {
         val accountId = 10L
         val teamId = 1L
         val command = AcceptInvitationCommand(accountId = accountId, teamId = teamId)
@@ -210,7 +220,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 수락 시 acceptInvitation은 activate를 호출한다`() {
+    @DisplayName("정상 수락 시 acceptInvitation은 activate를 호출한다")
+    fun acceptInvitation_activatesMember() {
         val accountId = 10L
         val teamId = 1L
         val memberId = 1L
@@ -231,7 +242,8 @@ class MemberServiceTest {
     // ───────────── leave ─────────────
 
     @Test
-    fun `마지막 admin이면 leave 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다`() {
+    @DisplayName("마지막 admin이면 leave 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다")
+    fun leave_throwsException_whenLastAdmin() {
         val accountId = 10L
         val teamId = 1L
         val memberId = 1L
@@ -252,7 +264,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 탈퇴 시 leave는 delete를 호출한다`() {
+    @DisplayName("정상 탈퇴 시 leave는 delete를 호출한다")
+    fun leave_deletesMember() {
         val accountId = 10L
         val teamId = 1L
         val memberId = 1L
@@ -268,7 +281,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `admin이 여러 명이면 leave 시 정상 탈퇴된다`() {
+    @DisplayName("admin이 여러 명이면 leave 시 정상 탈퇴된다")
+    fun leave_succeeds_whenMultipleAdminsExist() {
         val accountId = 10L
         val teamId = 1L
         val memberId = 1L
@@ -287,7 +301,8 @@ class MemberServiceTest {
     // ───────────── updateRole ─────────────
 
     @Test
-    fun `admin이 아니면 updateRole 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 updateRole 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun updateRole_throwsException_whenNotAdmin() {
         val accountId = 10L
         val teamId = 1L
         val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = 2L, role = MemberRole.ADMIN)
@@ -305,7 +320,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `다른 팀의 멤버를 변경하려 하면 updateRole 시 MEMBER_NOT_FOUND 예외가 발생한다`() {
+    @DisplayName("다른 팀의 멤버를 변경하려 하면 updateRole 시 MEMBER_NOT_FOUND 예외가 발생한다")
+    fun updateRole_throwsException_whenMemberInDifferentTeam() {
         val accountId = 10L
         val teamId = 1L
         val otherTeamId = 99L
@@ -327,7 +343,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `마지막 admin을 COMMON으로 강등하면 updateRole 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다`() {
+    @DisplayName("마지막 admin을 COMMON으로 강등하면 updateRole 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다")
+    fun updateRole_throwsException_whenDemotingLastAdmin() {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L
@@ -349,7 +366,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `admin이 여러 명이면 COMMON으로 강등할 수 있다`() {
+    @DisplayName("admin이 여러 명이면 COMMON으로 강등할 수 있다")
+    fun updateRole_demotesToCommon_whenMultipleAdminsExist() {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L
@@ -371,7 +389,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 역할 변경 시 updateRole은 updateRole을 호출한다`() {
+    @DisplayName("정상 역할 변경 시 updateRole은 updateRole을 호출한다")
+    fun updateRole_updatesRole() {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L
@@ -394,7 +413,8 @@ class MemberServiceTest {
     // ───────────── removeMember ─────────────
 
     @Test
-    fun `admin이 아니면 removeMember 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 removeMember 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun removeMember_throwsException_whenNotAdmin() {
         val accountId = 10L
         val teamId = 1L
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = 2L)
@@ -412,7 +432,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `자기 자신을 제거하려 하면 removeMember 시 CANNOT_REMOVE_SELF 예외가 발생한다`() {
+    @DisplayName("자기 자신을 제거하려 하면 removeMember 시 CANNOT_REMOVE_SELF 예외가 발생한다")
+    fun removeMember_throwsException_whenRemovingSelf() {
         val accountId = 10L
         val teamId = 1L
         val memberId = 1L
@@ -433,7 +454,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `마지막 admin을 제거하려 하면 removeMember 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다`() {
+    @DisplayName("마지막 admin을 제거하려 하면 removeMember 시 CANNOT_REMOVE_LAST_ADMIN 예외가 발생한다")
+    fun removeMember_throwsException_whenRemovingLastAdmin() {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L
@@ -455,7 +477,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `다른 팀의 멤버를 제거하려 하면 removeMember 시 MEMBER_NOT_FOUND 예외가 발생한다`() {
+    @DisplayName("다른 팀의 멤버를 제거하려 하면 removeMember 시 MEMBER_NOT_FOUND 예외가 발생한다")
+    fun removeMember_throwsException_whenMemberInDifferentTeam() {
         val accountId = 10L
         val teamId = 1L
         val otherTeamId = 99L
@@ -477,7 +500,8 @@ class MemberServiceTest {
     }
 
     @Test
-    fun `정상 제거 시 removeMember는 delete를 호출한다`() {
+    @DisplayName("정상 제거 시 removeMember는 delete를 호출한다")
+    fun removeMember_deletesMember() {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L

--- a/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
+++ b/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
@@ -2,6 +2,7 @@ package sharev.team.application.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
@@ -44,7 +45,8 @@ class TeamServiceTest {
     // ───────────── create ─────────────
 
     @Test
-    fun `팀 생성 시 팀을 저장하고 admin 멤버를 자동 생성한다`() {
+    @DisplayName("팀 생성 시 팀을 저장하고 admin 멤버를 자동 생성한다")
+    fun create_savesTeamAndCreatesAdminMember() {
         val accountId = 10L
         val command = CreateTeamCommand(accountId = accountId, title = "새 팀")
         val savedTeam = team(id = 1L, title = command.title)
@@ -60,7 +62,8 @@ class TeamServiceTest {
     // ───────────── getMyTeams ─────────────
 
     @Test
-    fun `getMyTeams는 내 팀 목록을 반환한다`() {
+    @DisplayName("getMyTeams는 내 팀 목록을 반환한다")
+    fun getMyTeams_returnsTeamList() {
         val accountId = 10L
         val command = GetMyTeamsCommand(accountId = accountId)
         val summaries = listOf(
@@ -81,7 +84,8 @@ class TeamServiceTest {
     // ───────────── getTeamDetail ─────────────
 
     @Test
-    fun `팀 멤버가 아니면 getTeamDetail 시 NOT_TEAM_MEMBER 예외가 발생한다`() {
+    @DisplayName("팀 멤버가 아니면 getTeamDetail 시 NOT_TEAM_MEMBER 예외가 발생한다")
+    fun getTeamDetail_throwsException_whenNotTeamMember() {
         val accountId = 10L
         val teamId = 1L
 
@@ -98,7 +102,8 @@ class TeamServiceTest {
     }
 
     @Test
-    fun `정상 조회 시 getTeamDetail은 gathering summaries, member summaries, headcount를 반환한다`() {
+    @DisplayName("정상 조회 시 getTeamDetail은 gathering summaries, member summaries, headcount를 반환한다")
+    fun getTeamDetail_returnsDetailWithGatheringsAndMembers() {
         val accountId = 10L
         val teamId = 1L
         val existingTeam = team(id = teamId, title = "팀A")
@@ -131,7 +136,8 @@ class TeamServiceTest {
     // ───────────── updateTeamInfo ─────────────
 
     @Test
-    fun `admin이 아니면 updateTeamInfo 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다`() {
+    @DisplayName("admin이 아니면 updateTeamInfo 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    fun updateTeamInfo_throwsException_whenNotAdmin() {
         val command = UpdateTeamInfoCommand(accountId = 10L, teamId = 1L, title = "새 제목")
 
         given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(false)
@@ -147,7 +153,8 @@ class TeamServiceTest {
     }
 
     @Test
-    fun `admin이면 updateTeamInfo 시 팀 제목을 수정하고 결과를 반환한다`() {
+    @DisplayName("admin이면 updateTeamInfo 시 팀 제목을 수정하고 결과를 반환한다")
+    fun updateTeamInfo_updatesTitle_whenAdmin() {
         val newTitle = "수정된 팀 이름"
         val command = UpdateTeamInfoCommand(accountId = 10L, teamId = 1L, title = newTitle)
         val updatedTeam = team(id = command.teamId, title = newTitle)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 계정 정보 업데이트 시 링크 일괄 추가/삭제 지원
  * 링크 최대 등록 수(3개) 제한 및 관련 오류 안내

* **리팩토링**
  * 계정 업데이트 흐름 간소화 및 반환 정보 정리(역할 제거, 업데이트 시각 추가)
  * 링크 저장/삭제 포트 및 저장소 인터페이스 개선

* **테스트**
  * 링크 업데이트 이벤트 처리 테스트 추가 및 다수 테스트명/표시명 정리

* **기타**
  * 정적 문서 복사 방식 개선 (빌드 출력 위치 표준화)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Nowdays-Goodnight-Cool-Niang/SharEv-Backend/pull/98)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->