### PR TITLE
Refactor/pagenation

### DIFF
--- a/src/main/kotlin/sharev/card/adapter/outbound/jpa/CardJpaAdapter.kt
+++ b/src/main/kotlin/sharev/card/adapter/outbound/jpa/CardJpaAdapter.kt
@@ -105,9 +105,8 @@ class CardJpaAdapter(
         return cardRepository.searchTempCards(gatheringId, myCardId, snapshotTime, pageable)
     }
 
-    override fun loadParticipatedGatherings(accountId: Long): List<Gathering> {
-        return cardRepository.findByAccountId(accountId)
-            .map { it.gathering }
-            .map { it.toDomainModel() }
+    override fun loadParticipatedGatherings(accountId: Long, pageable: Pageable): Page<Gathering> {
+        return cardRepository.findByAccountId(accountId, pageable)
+            .map { it.gathering.toDomainModel() }
     }
 }

--- a/src/main/kotlin/sharev/card/adapter/outbound/jpa/repository/CardRepository.kt
+++ b/src/main/kotlin/sharev/card/adapter/outbound/jpa/repository/CardRepository.kt
@@ -1,5 +1,7 @@
 package sharev.card.adapter.outbound.jpa.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import sharev.card.adapter.outbound.jpa.entity.CardJpaEntity
@@ -13,7 +15,7 @@ interface CardRepository : JpaRepository<CardJpaEntity, Long>,
 
     fun existsByGatheringIdAndAccountId(gatheringId: UUID, accountId: Long): Boolean
 
-    fun findByAccountId(accountId: Long): List<CardJpaEntity>
+    fun findByAccountId(accountId: Long, pageable: Pageable): Page<CardJpaEntity>
 
     @Query("select c.pinNumber from CardJpaEntity c where c.gathering.id = :gatheringId and c.pinNumber is not null")
     fun findPinNumbersByGatheringId(gatheringId: UUID): Set<Int>

--- a/src/main/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringController.kt
+++ b/src/main/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringController.kt
@@ -1,6 +1,8 @@
 package sharev.gathering.adapter.inbound.web.controller
 
 import jakarta.validation.Valid
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -28,9 +30,10 @@ class GatheringController(
 
     @GetMapping("/gatherings")
     fun allGatherings(
-    ): ResponseEntity<List<GatheringDetailResponse>> {
+        pageable: Pageable,
+    ): ResponseEntity<Page<GatheringDetailResponse>> {
         return ResponseEntity.ok(
-            getGatheringsUseCase.getGatherings()
+            getGatheringsUseCase.getGatherings(pageable)
                 .map { it.toResponse() }
         )
     }
@@ -38,9 +41,10 @@ class GatheringController(
     @GetMapping("/gatherings/me")
     fun participatedGatherings(
         @AuthenticationPrincipal accountPrincipal: AccountPrincipal,
-    ): ResponseEntity<List<GatheringDetailResponse>> {
+        pageable: Pageable,
+    ): ResponseEntity<Page<GatheringDetailResponse>> {
         return ResponseEntity.ok(
-            getParticipatedGatheringsUseCase.getParticipatedGatherings(accountPrincipal.id)
+            getParticipatedGatheringsUseCase.getParticipatedGatherings(accountPrincipal.id, pageable)
                 .map { it.toResponse() }
         )
     }

--- a/src/main/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringController.kt
+++ b/src/main/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringController.kt
@@ -3,6 +3,7 @@ package sharev.gathering.adapter.inbound.web.controller
 import jakarta.validation.Valid
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
@@ -30,7 +31,7 @@ class GatheringController(
 
     @GetMapping("/gatherings")
     fun allGatherings(
-        pageable: Pageable,
+        @PageableDefault(size = 20) pageable: Pageable,
     ): ResponseEntity<Page<GatheringDetailResponse>> {
         return ResponseEntity.ok(
             getGatheringsUseCase.getGatherings(pageable)
@@ -41,7 +42,7 @@ class GatheringController(
     @GetMapping("/gatherings/me")
     fun participatedGatherings(
         @AuthenticationPrincipal accountPrincipal: AccountPrincipal,
-        pageable: Pageable,
+        @PageableDefault(size = 20) pageable: Pageable,
     ): ResponseEntity<Page<GatheringDetailResponse>> {
         return ResponseEntity.ok(
             getParticipatedGatheringsUseCase.getParticipatedGatherings(accountPrincipal.id, pageable)

--- a/src/main/kotlin/sharev/gathering/adapter/outbound/jpa/GatheringJpaAdapter.kt
+++ b/src/main/kotlin/sharev/gathering/adapter/outbound/jpa/GatheringJpaAdapter.kt
@@ -1,5 +1,7 @@
 package sharev.gathering.adapter.outbound.jpa
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import sharev.gathering.adapter.outbound.jpa.entity.GatheringJpaEntity
@@ -97,8 +99,8 @@ class GatheringJpaAdapter(
             ?: throw GatheringException(GatheringCode.GATHERING_NOT_FOUND)
     }
 
-    override fun loadAll(): List<Gathering> {
-        return gatheringRepository.findAll()
+    override fun loadAll(pageable: Pageable): Page<Gathering> {
+        return gatheringRepository.findAll(pageable)
             .map { it.toDomainModel() }
     }
 

--- a/src/main/kotlin/sharev/gathering/application/port/inbound/usecase/GetGatheringsUseCase.kt
+++ b/src/main/kotlin/sharev/gathering/application/port/inbound/usecase/GetGatheringsUseCase.kt
@@ -1,7 +1,9 @@
 package sharev.gathering.application.port.inbound.usecase
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import sharev.gathering.application.port.inbound.result.GatheringDetailResult
 
 fun interface GetGatheringsUseCase {
-    fun getGatherings(): List<GatheringDetailResult>
+    fun getGatherings(pageable: Pageable): Page<GatheringDetailResult>
 }

--- a/src/main/kotlin/sharev/gathering/application/port/inbound/usecase/GetParticipatedGatheringsUseCase.kt
+++ b/src/main/kotlin/sharev/gathering/application/port/inbound/usecase/GetParticipatedGatheringsUseCase.kt
@@ -1,7 +1,9 @@
 package sharev.gathering.application.port.inbound.usecase
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import sharev.gathering.application.port.inbound.result.GatheringDetailResult
 
 fun interface GetParticipatedGatheringsUseCase {
-    fun getParticipatedGatherings(accountId: Long): List<GatheringDetailResult>
+    fun getParticipatedGatherings(accountId: Long, pageable: Pageable): Page<GatheringDetailResult>
 }

--- a/src/main/kotlin/sharev/gathering/application/port/outbound/LoadGatheringPort.kt
+++ b/src/main/kotlin/sharev/gathering/application/port/outbound/LoadGatheringPort.kt
@@ -1,10 +1,12 @@
 package sharev.gathering.application.port.outbound
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import sharev.gathering.domain.model.Gathering
 import java.util.*
 
 interface LoadGatheringPort {
     fun load(gatheringId: UUID): Gathering
-    fun loadAll(): List<Gathering>
+    fun loadAll(pageable: Pageable): Page<Gathering>
     fun loadAllByTeam(teamId: Long): List<Gathering>
 }

--- a/src/main/kotlin/sharev/gathering/application/port/outbound/LoadParticipatedGatheringsPort.kt
+++ b/src/main/kotlin/sharev/gathering/application/port/outbound/LoadParticipatedGatheringsPort.kt
@@ -1,7 +1,9 @@
 package sharev.gathering.application.port.outbound
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import sharev.gathering.domain.model.Gathering
 
 fun interface LoadParticipatedGatheringsPort {
-    fun loadParticipatedGatherings(accountId: Long): List<Gathering>
+    fun loadParticipatedGatherings(accountId: Long, pageable: Pageable): Page<Gathering>
 }

--- a/src/main/kotlin/sharev/gathering/application/service/GatheringService.kt
+++ b/src/main/kotlin/sharev/gathering/application/service/GatheringService.kt
@@ -1,5 +1,7 @@
 package sharev.gathering.application.service
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import sharev.gathering.application.port.inbound.command.CreateGatheringCommand
@@ -63,13 +65,13 @@ class GatheringService(
         ).toCreateGatheringResult()
     }
 
-    override fun getParticipatedGatherings(accountId: Long): List<GatheringDetailResult> {
-        return loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId)
+    override fun getParticipatedGatherings(accountId: Long, pageable: Pageable): Page<GatheringDetailResult> {
+        return loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId, pageable)
             .map { it.toDetailResult() }
     }
 
-    override fun getGatherings(): List<GatheringDetailResult> {
-        return loadGatheringPort.loadAll()
+    override fun getGatherings(pageable: Pageable): Page<GatheringDetailResult> {
+        return loadGatheringPort.loadAll(pageable)
             .map { it.toDetailResult() }
     }
 

--- a/src/test/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringControllerTest.kt
+++ b/src/test/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringControllerTest.kt
@@ -8,6 +8,8 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.willThrow
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.MediaType
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders
 import org.springframework.restdocs.payload.FieldDescriptor
@@ -34,11 +36,14 @@ class GatheringControllerTest : ControllerTestSupport() {
     @WithCustomMockUser
     @DisplayName("전체 행사 목록 조회")
     fun allGatherings() {
-        val response = listOf(gatheringResult(UUID.randomUUID()))
+        val pageable = PageRequest.of(0, 20)
+        val response = PageImpl(listOf(gatheringResult(UUID.randomUUID())), pageable, 1)
 
-        given(getGatheringsUseCase.getGatherings()).willReturn(response)
+        given(getGatheringsUseCase.getGatherings(pageable)).willReturn(response)
 
         val request = RestDocumentationRequestBuilders.get("/gatherings")
+            .param("page", "0")
+            .param("size", "20")
             .contentType(MediaType.APPLICATION_JSON)
 
         mockMvc.perform(request)
@@ -50,8 +55,9 @@ class GatheringControllerTest : ControllerTestSupport() {
                     resource(
                         ResourceSnippetParameters.builder()
                             .summary("전체 행사 목록 조회")
-                            .description("모든 행사 목록을 조회합니다.")
-                            .responseFields(*gatheringArrayFields())
+                            .description("모든 행사 목록을 페이지네이션으로 조회합니다.")
+                            .queryParameters(*pageableQueryParameters())
+                            .responseFields(*gatheringPageFields())
                             .responseSchema(schema(GatheringDetailResponse::class.java.simpleName))
                             .build()
                     )
@@ -63,11 +69,14 @@ class GatheringControllerTest : ControllerTestSupport() {
     @WithCustomMockUser
     @DisplayName("참여 행사 목록 조회")
     fun participatedGatherings() {
-        val response = listOf(gatheringResult(UUID.randomUUID()))
+        val pageable = PageRequest.of(0, 20)
+        val response = PageImpl(listOf(gatheringResult(UUID.randomUUID())), pageable, 1)
 
-        given(getParticipatedGatheringsUseCase.getParticipatedGatherings(1L)).willReturn(response)
+        given(getParticipatedGatheringsUseCase.getParticipatedGatherings(1L, pageable)).willReturn(response)
 
         val request = RestDocumentationRequestBuilders.get("/gatherings/me")
+            .param("page", "0")
+            .param("size", "20")
             .contentType(MediaType.APPLICATION_JSON)
 
         mockMvc.perform(request)
@@ -79,8 +88,9 @@ class GatheringControllerTest : ControllerTestSupport() {
                     resource(
                         ResourceSnippetParameters.builder()
                             .summary("참여 행사 목록 조회")
-                            .description("사용자가 참여한 행사 목록을 조회합니다.")
-                            .responseFields(*gatheringArrayFields())
+                            .description("사용자가 참여한 행사 목록을 페이지네이션으로 조회합니다.")
+                            .queryParameters(*pageableQueryParameters())
+                            .responseFields(*gatheringPageFields())
                             .responseSchema(schema(GatheringDetailResponse::class.java.simpleName))
                             .build()
                     )
@@ -648,5 +658,31 @@ class GatheringControllerTest : ControllerTestSupport() {
         fieldWithPath("[].contact").type(STRING).description("연락처").optional(),
         fieldWithPath("[].registerStartAt").type(STRING).description("참가 등록 시작일시"),
         fieldWithPath("[].registerEndAt").type(STRING).description("참가 등록 종료일시"),
+    )
+
+    private fun pageableQueryParameters() = arrayOf(
+        parameterWithName("page").description("페이지 번호 (0부터 시작)").optional(),
+        parameterWithName("size").description("페이지 크기").optional(),
+        parameterWithName("sort").description("정렬 기준 (예: startAt,desc)").optional(),
+    )
+
+    private fun gatheringPageFields(): Array<FieldDescriptor> = arrayOf(
+        fieldWithPath("content[].id").type(STRING).description("행사 ID (UUID)"),
+        fieldWithPath("content[].visible").type(STRING).description("공개 범위 (PUBLIC, PRIVATE)"),
+        fieldWithPath("content[].title").type(STRING).description("행사 제목"),
+        fieldWithPath("content[].content").type(STRING).description("행사 설명"),
+        fieldWithPath("content[].startAt").type(STRING).description("행사 시작일시"),
+        fieldWithPath("content[].endAt").type(STRING).description("행사 종료일시"),
+        fieldWithPath("content[].place").type(STRING).description("행사 장소"),
+        fieldWithPath("content[].imageUrl").type(STRING).description("행사 이미지 URL").optional(),
+        fieldWithPath("content[].gatheringUrl").type(STRING).description("행사 관련 URL").optional(),
+        fieldWithPath("content[].contact").type(STRING).description("연락처").optional(),
+        fieldWithPath("content[].registerStartAt").type(STRING).description("참가 등록 시작일시"),
+        fieldWithPath("content[].registerEndAt").type(STRING).description("참가 등록 종료일시"),
+        fieldWithPath("page").type("OBJECT").description("페이지 정보"),
+        fieldWithPath("page.size").type(NUMBER).description("페이지 크기"),
+        fieldWithPath("page.number").type(NUMBER).description("현재 페이지"),
+        fieldWithPath("page.totalElements").type(NUMBER).description("총 요소 수"),
+        fieldWithPath("page.totalPages").type(NUMBER).description("총 페이지 수"),
     )
 }

--- a/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
+++ b/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
@@ -10,6 +10,8 @@ import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
 import sharev.gathering.application.port.inbound.command.CreateGatheringCommand
 import sharev.gathering.application.port.inbound.command.UpdateGatheringCommand
 import sharev.gathering.application.port.outbound.CheckGatheringParticipantPort
@@ -87,30 +89,34 @@ class GatheringParticipantServiceTest {
     @DisplayName("getParticipatedGatherings는 참여 중인 행사 목록을 반환한다")
     fun getParticipatedGatherings_returnsGatheringList() {
         val accountId = 1L
+        val pageable = PageRequest.of(0, 10)
         val gatheringList = listOf(
             gathering(id = UUID.randomUUID(), teamId = 1L, title = "참여 행사1"),
             gathering(id = UUID.randomUUID(), teamId = 2L, title = "참여 행사2"),
         )
 
-        given(loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId)).willReturn(gatheringList)
+        given(loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId, pageable))
+            .willReturn(PageImpl(gatheringList, pageable, gatheringList.size.toLong()))
 
-        val result = gatheringParticipantService.getParticipatedGatherings(accountId)
+        val result = gatheringParticipantService.getParticipatedGatherings(accountId, pageable)
 
-        assertThat(result).hasSize(2)
-        assertThat(result[0].title).isEqualTo("참여 행사1")
-        assertThat(result[1].title).isEqualTo("참여 행사2")
+        assertThat(result.totalElements).isEqualTo(2)
+        assertThat(result.content[0].title).isEqualTo("참여 행사1")
+        assertThat(result.content[1].title).isEqualTo("참여 행사2")
     }
 
     @Test
     @DisplayName("참여 행사가 없으면 빈 목록을 반환한다")
     fun getParticipatedGatherings_returnsEmptyList() {
         val accountId = 1L
+        val pageable = PageRequest.of(0, 10)
 
-        given(loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId)).willReturn(emptyList())
+        given(loadParticipatedGatheringsPort.loadParticipatedGatherings(accountId, pageable))
+            .willReturn(PageImpl(emptyList(), pageable, 0))
 
-        val result = gatheringParticipantService.getParticipatedGatherings(accountId)
+        val result = gatheringParticipantService.getParticipatedGatherings(accountId, pageable)
 
-        assertThat(result).isEmpty()
+        assertThat(result.content).isEmpty()
     }
 
     // ───────────── getGatherings (all public) ─────────────
@@ -118,28 +124,32 @@ class GatheringParticipantServiceTest {
     @Test
     @DisplayName("getGatherings는 전체 행사 목록을 반환한다")
     fun getGatherings_returnsAllGatherings() {
+        val pageable = PageRequest.of(0, 10)
         val gatheringList = listOf(
             gathering(id = UUID.randomUUID(), teamId = 1L, title = "행사1"),
             gathering(id = UUID.randomUUID(), teamId = 2L, title = "행사2"),
         )
 
-        given(loadGatheringPort.loadAll()).willReturn(gatheringList)
+        given(loadGatheringPort.loadAll(pageable))
+            .willReturn(PageImpl(gatheringList, pageable, gatheringList.size.toLong()))
 
-        val result = gatheringParticipantService.getGatherings()
+        val result = gatheringParticipantService.getGatherings(pageable)
 
-        assertThat(result).hasSize(2)
-        assertThat(result[0].title).isEqualTo("행사1")
-        assertThat(result[1].title).isEqualTo("행사2")
+        assertThat(result.totalElements).isEqualTo(2)
+        assertThat(result.content[0].title).isEqualTo("행사1")
+        assertThat(result.content[1].title).isEqualTo("행사2")
     }
 
     @Test
     @DisplayName("행사가 없으면 빈 목록을 반환한다")
     fun getGatherings_returnsEmptyList() {
-        given(loadGatheringPort.loadAll()).willReturn(emptyList())
+        val pageable = PageRequest.of(0, 10)
 
-        val result = gatheringParticipantService.getGatherings()
+        given(loadGatheringPort.loadAll(pageable)).willReturn(PageImpl(emptyList(), pageable, 0))
 
-        assertThat(result).isEmpty()
+        val result = gatheringParticipantService.getGatherings(pageable)
+
+        assertThat(result.content).isEmpty()
     }
 
     // ───────────── getTeamGatherings ─────────────


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 모임 목록 조회 및 참가 모임 조회에 페이지네이션이 적용되었습니다. 쿼리 파라미터로 페이지 번호와 크기를 지정해 결과를 분할 조회할 수 있습니다.

* **Bug Fixes**
  * 페이지네이션 응답 형식으로 일관되게 제공되도록 응답 매핑이 개선되었습니다.

* **Tests**
  * 페이지네이션 기준으로 컨트롤러 및 서비스 테스트를 수정했습니다. (응답을 `content` 및 페이지 메타 기준으로 검증)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->