### PR TITLE
Feat/team personal

### DIFF
--- a/src/main/kotlin/sharev/account/adapter/outbound/jpa/repository/AccountRepository.kt
+++ b/src/main/kotlin/sharev/account/adapter/outbound/jpa/repository/AccountRepository.kt
@@ -2,10 +2,9 @@ package sharev.account.adapter.outbound.jpa.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import sharev.account.adapter.outbound.jpa.entity.AccountJpaEntity
-import java.util.*
 
 interface AccountRepository : JpaRepository<AccountJpaEntity, Long> {
-    fun findByEmail(email: String): Optional<AccountJpaEntity>
+    fun findByHandle(handle: String): AccountJpaEntity?
 
     fun existsByHandleAndIdNot(handle: String, id: Long): Boolean
 }

--- a/src/main/kotlin/sharev/account/application/service/OAuthAccountService.kt
+++ b/src/main/kotlin/sharev/account/application/service/OAuthAccountService.kt
@@ -9,9 +9,11 @@ import sharev.account.application.port.outbound.LoadAccountPort
 import sharev.account.application.port.outbound.LoadOAuthAccountPort
 import sharev.account.application.port.outbound.SaveAccountPort
 import sharev.account.application.port.outbound.SaveOAuthAccountPort
+import sharev.account.domain.event.AccountSignupEvent
 import sharev.account.domain.model.Account
 import sharev.account.domain.model.AccountRole
 import sharev.account.domain.model.OAuthAccount
+import sharev.common.application.port.outbound.PublishEventPort
 
 @Service
 @Transactional(readOnly = true)
@@ -20,6 +22,7 @@ class OAuthAccountService(
     private val saveOAuthAccountPort: SaveOAuthAccountPort,
     private val loadAccountPort: LoadAccountPort,
     private val saveAccountPort: SaveAccountPort,
+    private val publishEventPort: PublishEventPort,
 ) : OAuthLoginUseCase {
 
     @Transactional
@@ -40,6 +43,7 @@ class OAuthAccountService(
     private fun signup(command: OAuthLoginCommand): Account {
         val account = saveAccountPort.save(Account(0L, command.name, command.email, AccountRole.USER, null))
         saveOAuthAccountPort.save(OAuthAccount(command.provider, command.subjectIdentifier, account.id))
+        publishEventPort.publish(AccountSignupEvent(account.id))
         return account
     }
 }

--- a/src/main/kotlin/sharev/account/domain/event/AccountSignupEvent.kt
+++ b/src/main/kotlin/sharev/account/domain/event/AccountSignupEvent.kt
@@ -1,0 +1,5 @@
+package sharev.account.domain.event
+
+data class AccountSignupEvent(
+    val accountId: Long,
+)

--- a/src/main/kotlin/sharev/gathering/adapter/outbound/jpa/GatheringJpaAdapter.kt
+++ b/src/main/kotlin/sharev/gathering/adapter/outbound/jpa/GatheringJpaAdapter.kt
@@ -17,7 +17,7 @@ import sharev.gathering.domain.model.Gathering
 import sharev.gathering.domain.model.IntroduceTemplate
 import sharev.gathering.domain.model.IntroduceTemplateContent
 import sharev.team.adapter.outbound.jpa.repository.TeamRepository
-import sharev.team.application.port.outbound.LoadGatheringSummaryPort
+import sharev.team.application.port.outbound.QueryGatheringPort
 import sharev.team.application.port.outbound.summary.GatheringSummary
 import sharev.team.domain.exception.TeamException
 import java.util.*
@@ -32,7 +32,7 @@ class GatheringJpaAdapter(
 ) : SaveGatheringPort,
     LoadGatheringPort,
     LoadIntroduceTemplatePort,
-    LoadGatheringSummaryPort {
+    QueryGatheringPort {
 
     override fun save(gathering: Gathering): Gathering {
         val team = teamRepository.findByIdOrNull(gathering.teamId)
@@ -124,7 +124,7 @@ class GatheringJpaAdapter(
             .toDomainModel()
     }
 
-    override fun loadByTeam(teamId: Long): List<GatheringSummary> {
+    override fun findByTeam(teamId: Long): List<GatheringSummary> {
         return loadAllByTeam(teamId).map {
             GatheringSummary(it.title, it.startAt, it.endAt, it.place)
         }

--- a/src/main/kotlin/sharev/gathering/application/service/GatheringService.kt
+++ b/src/main/kotlin/sharev/gathering/application/service/GatheringService.kt
@@ -15,7 +15,7 @@ import sharev.gathering.application.port.outbound.*
 import sharev.gathering.domain.exception.GatheringException
 import sharev.gathering.domain.exception.GatheringExceptionCode
 import sharev.gathering.domain.model.Gathering
-import sharev.team.application.port.outbound.CheckTeamMemberPort
+import sharev.team.application.port.outbound.TeamAccessPort
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import java.util.*
@@ -27,7 +27,7 @@ class GatheringService(
     private val saveGatheringPort: SaveGatheringPort,
     private val loadGatheringPort: LoadGatheringPort,
     private val loadIntroduceTemplatePort: LoadIntroduceTemplatePort,
-    private val checkTeamMemberPort: CheckTeamMemberPort,
+    private val teamAccessPort: TeamAccessPort,
     private val loadParticipatedGatheringsPort: LoadParticipatedGatheringsPort,
 ) : CheckGatheringParticipantUseCase,
     CreateGatheringUseCase,
@@ -44,7 +44,7 @@ class GatheringService(
 
     @Transactional
     override fun create(command: CreateGatheringCommand): CreateGatheringResult {
-        validateTeamAdmin(command.accountId, command.teamId)
+        validateTeamManage(command.accountId, command.teamId)
 
         return saveGatheringPort.save(
             Gathering(
@@ -76,14 +76,14 @@ class GatheringService(
     }
 
     override fun getTeamGatherings(accountId: Long, teamId: Long): List<GatheringDetailResult> {
-        validateTeamMember(accountId, teamId)
+        validateTeamAccess(accountId, teamId)
 
         return loadGatheringPort.loadAllByTeam(teamId)
             .map { it.toDetailResult() }
     }
 
     override fun getTeamGathering(accountId: Long, teamId: Long, gatheringId: UUID): GatheringDetailResult {
-        validateTeamMember(accountId, teamId)
+        validateTeamAccess(accountId, teamId)
 
         val gathering = loadGatheringPort.load(gatheringId)
 
@@ -96,7 +96,7 @@ class GatheringService(
 
     @Transactional
     override fun update(command: UpdateGatheringCommand): GatheringDetailResult {
-        validateTeamAdmin(command.accountId, command.teamId)
+        validateTeamManage(command.accountId, command.teamId)
 
         return saveGatheringPort.update(
             Gathering(
@@ -119,7 +119,7 @@ class GatheringService(
 
     @Transactional
     override fun delete(accountId: Long, teamId: Long, gatheringId: UUID): DeleteGatheringResult {
-        validateTeamAdmin(accountId, teamId)
+        validateTeamManage(accountId, teamId)
         validateGatheringBelongsToTeam(teamId, gatheringId)
 
         saveGatheringPort.softDelete(gatheringId)
@@ -143,15 +143,15 @@ class GatheringService(
         }
     }
 
-    private fun validateTeamMember(accountId: Long, teamId: Long) {
-        if (!checkTeamMemberPort.isMember(accountId, teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_MEMBER)
+    private fun validateTeamAccess(accountId: Long, teamId: Long) {
+        if (!teamAccessPort.hasAccess(accountId, teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS)
         }
     }
 
-    private fun validateTeamAdmin(accountId: Long, teamId: Long) {
-        if (!checkTeamMemberPort.isAdminMember(accountId, teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER)
+    private fun validateTeamManage(accountId: Long, teamId: Long) {
+        if (!teamAccessPort.canManage(accountId, teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE)
         }
     }
 }

--- a/src/main/kotlin/sharev/member/adapter/inbound/web/controller/MemberController.kt
+++ b/src/main/kotlin/sharev/member/adapter/inbound/web/controller/MemberController.kt
@@ -1,7 +1,6 @@
 package sharev.member.adapter.inbound.web.controller
 
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.*
@@ -49,8 +48,7 @@ class MemberController(
         val response = inviteMemberUseCase.invite(request.toCommand(accountPrincipal, teamId))
             .toResponse()
 
-        return ResponseEntity.status(HttpStatus.CREATED)
-            .body(response)
+        return ResponseEntity.ok(response)
     }
 
     @PatchMapping("/me/accept")

--- a/src/main/kotlin/sharev/member/adapter/inbound/web/dto/request/InviteMemberRequest.kt
+++ b/src/main/kotlin/sharev/member/adapter/inbound/web/dto/request/InviteMemberRequest.kt
@@ -1,10 +1,8 @@
 package sharev.member.adapter.inbound.web.dto.request
 
-import jakarta.validation.constraints.Email
 import jakarta.validation.constraints.NotBlank
 
 data class InviteMemberRequest(
     @field:NotBlank
-    @field:Email
-    val email: String,
+    val handle: String,
 )

--- a/src/main/kotlin/sharev/member/adapter/inbound/web/mapper/MemberWebMapper.kt
+++ b/src/main/kotlin/sharev/member/adapter/inbound/web/mapper/MemberWebMapper.kt
@@ -9,7 +9,7 @@ import sharev.member.application.port.inbound.command.UpdateMemberRoleCommand
 import sharev.member.application.port.inbound.result.*
 
 fun InviteMemberRequest.toCommand(accountPrincipal: AccountPrincipal, teamId: Long) =
-    InviteMemberCommand(accountPrincipal.id, teamId, email)
+    InviteMemberCommand(accountPrincipal.id, teamId, handle)
 
 fun UpdateMemberRoleRequest.toCommand(accountPrincipal: AccountPrincipal, teamId: Long, memberId: Long) =
     UpdateMemberRoleCommand(accountPrincipal.id, teamId, memberId, role!!)

--- a/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
+++ b/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
@@ -9,18 +9,15 @@ import sharev.common.adapter.outbound.jpa.exception.onUniqueViolation
 import sharev.member.adapter.outbound.jpa.entity.MemberJpaEntity
 import sharev.member.adapter.outbound.jpa.mapper.toDomainModel
 import sharev.member.adapter.outbound.jpa.repository.MemberRepository
-import sharev.member.application.port.outbound.DeleteMemberPort
-import sharev.member.application.port.outbound.LoadAccountForMemberPort
-import sharev.member.application.port.outbound.LoadMemberPort
-import sharev.member.application.port.outbound.SaveMemberPort
+import sharev.member.application.port.outbound.*
 import sharev.member.domain.exception.MemberException
 import sharev.member.domain.exception.MemberExceptionCode
 import sharev.member.domain.model.Member
 import sharev.member.domain.model.MemberRole
 import sharev.member.domain.model.MemberStatus
 import sharev.team.adapter.outbound.jpa.repository.TeamRepository
-import sharev.team.application.port.outbound.CheckTeamMemberPort
-import sharev.team.application.port.outbound.SaveTeamAdminMemberPort
+import sharev.team.application.port.outbound.SaveTeamAdminPort
+import sharev.team.application.port.outbound.TeamAccessPort
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 
@@ -30,11 +27,12 @@ class MemberJpaAdapter(
     private val teamRepository: TeamRepository,
     private val accountRepository: AccountRepository,
 ) : SaveMemberPort,
-    SaveTeamAdminMemberPort,
+    SaveTeamAdminPort,
     LoadMemberPort,
     DeleteMemberPort,
     LoadAccountForMemberPort,
-    CheckTeamMemberPort {
+    TeamAccessPort,
+    CheckMemberPort {
 
     override fun save(
         teamId: Long,
@@ -116,14 +114,15 @@ class MemberJpaAdapter(
             .map { it.toDomainModel() }
     }
 
-    override fun isMember(accountId: Long, teamId: Long): Boolean {
+    override fun hasAccess(accountId: Long, teamId: Long): Boolean {
         val team = teamRepository.findByIdOrNull(teamId) ?: return false
-        return memberRepository.findByTeamAndAccountId(team, accountId) != null
+        return memberRepository.findByTeamAndAccountId(team, accountId)?.status == MemberStatus.ACTIVATE
     }
 
-    override fun isAdminMember(accountId: Long, teamId: Long): Boolean {
+    override fun canManage(accountId: Long, teamId: Long): Boolean {
         val team = teamRepository.findByIdOrNull(teamId) ?: return false
-        return memberRepository.findByTeamAndAccountId(team, accountId)?.role == MemberRole.ADMIN
+        val member = memberRepository.findByTeamAndAccountId(team, accountId) ?: return false
+        return member.role == MemberRole.ADMIN && member.status == MemberStatus.ACTIVATE
     }
 
     override fun countByTeamAndRole(teamId: Long, role: MemberRole): Long {
@@ -137,9 +136,14 @@ class MemberJpaAdapter(
         memberRepository.deleteById(memberId)
     }
 
-    override fun loadAccountIdByEmail(email: String): Long {
-        return accountRepository.findByEmail(email)
-            .orElseThrow { AccountException(AccountExceptionCode.ACCOUNT_NOT_FOUND) }
-            .id!!
+    override fun loadAccountIdByHandle(handle: String): Long {
+        val account = accountRepository.findByHandle(handle)
+            ?: throw AccountException(AccountExceptionCode.ACCOUNT_NOT_FOUND)
+
+        return account.id!!
+    }
+
+    override fun isMember(teamId: Long, accountId: Long): Boolean {
+        return memberRepository.existsByTeamIdAndAccountId(teamId, accountId)
     }
 }

--- a/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
+++ b/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
@@ -143,7 +143,7 @@ class MemberJpaAdapter(
         return account.id!!
     }
 
-    override fun isMember(teamId: Long, accountId: Long): Boolean {
+    override fun isMember(accountId: Long, teamId: Long): Boolean {
         return memberRepository.existsByTeamIdAndAccountId(teamId, accountId)
     }
 }

--- a/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
+++ b/src/main/kotlin/sharev/member/adapter/outbound/jpa/MemberJpaAdapter.kt
@@ -57,7 +57,7 @@ class MemberJpaAdapter(
         }
     }
 
-    override fun saveTeamAdmin(teamId: Long, accountId: Long) {
+    override fun save(teamId: Long, accountId: Long) {
         val team = teamRepository.findByIdOrNull(teamId)
             ?: throw TeamException(TeamExceptionCode.TEAM_NOT_FOUND)
         val account = accountRepository.findByIdOrNull(accountId)

--- a/src/main/kotlin/sharev/member/adapter/outbound/jpa/repository/MemberRepository.kt
+++ b/src/main/kotlin/sharev/member/adapter/outbound/jpa/repository/MemberRepository.kt
@@ -2,15 +2,11 @@ package sharev.member.adapter.outbound.jpa.repository
 
 import org.springframework.data.jpa.repository.EntityGraph
 import org.springframework.data.jpa.repository.JpaRepository
-import sharev.account.adapter.outbound.jpa.entity.AccountJpaEntity
 import sharev.member.adapter.outbound.jpa.entity.MemberJpaEntity
 import sharev.member.domain.model.MemberRole
 import sharev.team.adapter.outbound.jpa.entity.TeamJpaEntity
 
 interface MemberRepository : JpaRepository<MemberJpaEntity, Long> {
-    fun findAllByAccount(account: AccountJpaEntity): List<MemberJpaEntity>
-
-    fun findByTeamAndAccount(team: TeamJpaEntity, account: AccountJpaEntity): MemberJpaEntity?
 
     fun findByTeamAndAccountId(team: TeamJpaEntity, accountId: Long): MemberJpaEntity?
 
@@ -18,8 +14,6 @@ interface MemberRepository : JpaRepository<MemberJpaEntity, Long> {
 
     @EntityGraph(attributePaths = ["account"])
     fun findAllByTeam(team: TeamJpaEntity): List<MemberJpaEntity>
-
-    fun findByTeamAndAccountEmail(team: TeamJpaEntity, email: String): MemberJpaEntity?
 
     fun countByTeamAndRole(team: TeamJpaEntity, role: MemberRole): Long
 }

--- a/src/main/kotlin/sharev/member/adapter/outbound/jpa/repository/MemberRepository.kt
+++ b/src/main/kotlin/sharev/member/adapter/outbound/jpa/repository/MemberRepository.kt
@@ -14,6 +14,8 @@ interface MemberRepository : JpaRepository<MemberJpaEntity, Long> {
 
     fun findByTeamAndAccountId(team: TeamJpaEntity, accountId: Long): MemberJpaEntity?
 
+    fun existsByTeamIdAndAccountId(teamId: Long, accountId: Long): Boolean
+
     @EntityGraph(attributePaths = ["account"])
     fun findAllByTeam(team: TeamJpaEntity): List<MemberJpaEntity>
 

--- a/src/main/kotlin/sharev/member/application/port/inbound/command/InviteMemberCommand.kt
+++ b/src/main/kotlin/sharev/member/application/port/inbound/command/InviteMemberCommand.kt
@@ -3,5 +3,5 @@ package sharev.member.application.port.inbound.command
 data class InviteMemberCommand(
     val accountId: Long,
     val teamId: Long,
-    val email: String,
+    val handle: String,
 )

--- a/src/main/kotlin/sharev/member/application/port/outbound/CheckMemberPort.kt
+++ b/src/main/kotlin/sharev/member/application/port/outbound/CheckMemberPort.kt
@@ -1,0 +1,5 @@
+package sharev.member.application.port.outbound
+
+fun interface CheckMemberPort {
+    fun isMember(teamId: Long, accountId: Long): Boolean
+}

--- a/src/main/kotlin/sharev/member/application/port/outbound/CheckMemberPort.kt
+++ b/src/main/kotlin/sharev/member/application/port/outbound/CheckMemberPort.kt
@@ -1,5 +1,5 @@
 package sharev.member.application.port.outbound
 
 fun interface CheckMemberPort {
-    fun isMember(teamId: Long, accountId: Long): Boolean
+    fun isMember(accountId: Long, teamId: Long): Boolean
 }

--- a/src/main/kotlin/sharev/member/application/port/outbound/LoadAccountForMemberPort.kt
+++ b/src/main/kotlin/sharev/member/application/port/outbound/LoadAccountForMemberPort.kt
@@ -1,5 +1,5 @@
 package sharev.member.application.port.outbound
 
 fun interface LoadAccountForMemberPort {
-    fun loadAccountIdByEmail(email: String): Long
+    fun loadAccountIdByHandle(handle: String): Long
 }

--- a/src/main/kotlin/sharev/member/application/service/MemberService.kt
+++ b/src/main/kotlin/sharev/member/application/service/MemberService.kt
@@ -6,11 +6,7 @@ import sharev.member.application.port.inbound.command.*
 import sharev.member.application.port.inbound.mapper.*
 import sharev.member.application.port.inbound.result.*
 import sharev.member.application.port.inbound.usecase.*
-import sharev.member.application.port.outbound.CheckMemberPort
-import sharev.member.application.port.outbound.DeleteMemberPort
-import sharev.member.application.port.outbound.LoadAccountForMemberPort
-import sharev.member.application.port.outbound.LoadMemberPort
-import sharev.member.application.port.outbound.SaveMemberPort
+import sharev.member.application.port.outbound.*
 import sharev.member.domain.exception.MemberException
 import sharev.member.domain.exception.MemberExceptionCode
 import sharev.member.domain.model.Member
@@ -60,7 +56,7 @@ class MemberService(
 
         val targetAccountId = loadAccountForMemberPort.loadAccountIdByHandle(command.handle)
 
-        if (checkMemberPort.isMember(command.teamId, targetAccountId)) {
+        if (checkMemberPort.isMember(targetAccountId, command.teamId)) {
             throw MemberException(MemberExceptionCode.MEMBER_ALREADY_EXISTS)
         }
 

--- a/src/main/kotlin/sharev/member/application/service/MemberService.kt
+++ b/src/main/kotlin/sharev/member/application/service/MemberService.kt
@@ -6,6 +6,7 @@ import sharev.member.application.port.inbound.command.*
 import sharev.member.application.port.inbound.mapper.*
 import sharev.member.application.port.inbound.result.*
 import sharev.member.application.port.inbound.usecase.*
+import sharev.member.application.port.outbound.CheckMemberPort
 import sharev.member.application.port.outbound.DeleteMemberPort
 import sharev.member.application.port.outbound.LoadAccountForMemberPort
 import sharev.member.application.port.outbound.LoadMemberPort
@@ -15,8 +16,8 @@ import sharev.member.domain.exception.MemberExceptionCode
 import sharev.member.domain.model.Member
 import sharev.member.domain.model.MemberRole
 import sharev.member.domain.model.MemberStatus
-import sharev.team.application.port.outbound.CheckTeamMemberPort
 import sharev.team.application.port.outbound.LoadTeamPort
+import sharev.team.application.port.outbound.TeamAccessPort
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 
@@ -28,7 +29,8 @@ class MemberService(
     private val saveMemberPort: SaveMemberPort,
     private val deleteMemberPort: DeleteMemberPort,
     private val loadAccountForMemberPort: LoadAccountForMemberPort,
-    private val checkTeamMemberPort: CheckTeamMemberPort,
+    private val teamAccessPort: TeamAccessPort,
+    private val checkMemberPort: CheckMemberPort,
 ) : GetMembersUseCase,
     InviteMemberUseCase,
     AcceptInvitationUseCase,
@@ -42,7 +44,7 @@ class MemberService(
             return false
         }
 
-        return checkTeamMemberPort.isAdminMember(accountId, teamId)
+        return teamAccessPort.canManage(accountId, teamId)
     }
 
     override fun getMembers(command: GetMembersCommand): List<MemberResult> {
@@ -56,9 +58,9 @@ class MemberService(
     override fun invite(command: InviteMemberCommand): InviteMemberResult {
         validateTeamAdmin(command.accountId, command.teamId)
 
-        val targetAccountId = loadAccountForMemberPort.loadAccountIdByEmail(command.email)
+        val targetAccountId = loadAccountForMemberPort.loadAccountIdByHandle(command.handle)
 
-        if (checkTeamMemberPort.isMember(targetAccountId, command.teamId)) {
+        if (checkMemberPort.isMember(command.teamId, targetAccountId)) {
             throw MemberException(MemberExceptionCode.MEMBER_ALREADY_EXISTS)
         }
 
@@ -128,14 +130,14 @@ class MemberService(
     }
 
     private fun validateTeamMember(accountId: Long, teamId: Long) {
-        if (!checkTeamMemberPort.isMember(accountId, teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_MEMBER)
+        if (!teamAccessPort.hasAccess(accountId, teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS)
         }
     }
 
     private fun validateTeamAdmin(accountId: Long, teamId: Long) {
-        if (!checkTeamMemberPort.isAdminMember(accountId, teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER)
+        if (!teamAccessPort.canManage(accountId, teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE)
         }
     }
 

--- a/src/main/kotlin/sharev/team/adapter/inbound/event/AccountSignupEventListener.kt
+++ b/src/main/kotlin/sharev/team/adapter/inbound/event/AccountSignupEventListener.kt
@@ -1,0 +1,19 @@
+package sharev.team.adapter.inbound.event
+
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import sharev.account.domain.event.AccountSignupEvent
+import sharev.team.application.port.inbound.command.CreateTeamCommand
+import sharev.team.application.port.inbound.usecase.CreateTeamUseCase
+import sharev.team.domain.model.TeamType
+
+@Component
+class AccountSignupEventListener(
+    private val createTeamUseCase: CreateTeamUseCase,
+) {
+
+    @EventListener
+    fun handle(event: AccountSignupEvent) {
+        createTeamUseCase.create(CreateTeamCommand(event.accountId, null, "", TeamType.PERSONAL))
+    }
+}

--- a/src/main/kotlin/sharev/team/adapter/inbound/web/dto/response/TeamDetailResponse.kt
+++ b/src/main/kotlin/sharev/team/adapter/inbound/web/dto/response/TeamDetailResponse.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class TeamDetailResponse(
     val id: Long,
-    val title: String,
+    val title: String?,
     val content: String?,
     val createdAt: LocalDateTime?,
     val headcount: Int,

--- a/src/main/kotlin/sharev/team/adapter/inbound/web/dto/response/TeamInfoResponse.kt
+++ b/src/main/kotlin/sharev/team/adapter/inbound/web/dto/response/TeamInfoResponse.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class TeamInfoResponse(
     val id: Long,
-    val title: String,
+    val title: String?,
     val content: String?,
     val createdAt: LocalDateTime?,
     val memberRole: String,

--- a/src/main/kotlin/sharev/team/adapter/inbound/web/mapper/TeamWebMapper.kt
+++ b/src/main/kotlin/sharev/team/adapter/inbound/web/mapper/TeamWebMapper.kt
@@ -9,8 +9,9 @@ import sharev.team.application.port.inbound.result.CreateTeamResult
 import sharev.team.application.port.inbound.result.TeamDetailResult
 import sharev.team.application.port.inbound.result.TeamInfoResult
 import sharev.team.application.port.inbound.result.TeamUpdateInfoResult
+import sharev.team.domain.model.TeamType
 
-fun CreateTeamRequest.toCommand(accountId: Long) = CreateTeamCommand(accountId, title, content)
+fun CreateTeamRequest.toCommand(accountId: Long) = CreateTeamCommand(accountId, title, content, TeamType.PUBLIC)
 
 fun CreateTeamResult.toResponse() = CreateTeamResponse(teamId)
 

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/TeamJpaAdapter.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/TeamJpaAdapter.kt
@@ -14,15 +14,16 @@ import sharev.team.application.port.outbound.summary.TeamSummary
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.Team
+import sharev.team.domain.model.TeamType
 
 @Component
 class TeamJpaAdapter(
     private val teamRepository: TeamRepository,
 ) : SaveTeamPort, LoadTeamPort, QueryTeamPort {
 
-    override fun save(title: String, content: String): Team {
+    override fun save(title: String?, content: String, type: TeamType): Team {
         return onUniqueViolation({ TeamException(TeamExceptionCode.DUPLICATE_TEAM_NAME) }) {
-            teamRepository.save(TeamJpaEntity(title = title, content = content))
+            teamRepository.save(TeamJpaEntity(title = title, content = content, type = type))
                 .toDomainModel()
         }
     }

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/TeamJpaAdapter.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/TeamJpaAdapter.kt
@@ -3,39 +3,40 @@ package sharev.team.adapter.outbound.jpa
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Component
 import sharev.common.adapter.outbound.jpa.exception.onUniqueViolation
-import sharev.team.adapter.outbound.jpa.entity.TeamJpaEntity
 import sharev.team.adapter.outbound.jpa.mapper.toDomainModel
+import sharev.team.adapter.outbound.jpa.mapper.toJpaEntity
 import sharev.team.adapter.outbound.jpa.repository.TeamRepository
 import sharev.team.application.port.outbound.LoadTeamPort
 import sharev.team.application.port.outbound.QueryTeamPort
 import sharev.team.application.port.outbound.SaveTeamPort
+import sharev.team.application.port.outbound.summary.MyTeamSummary
 import sharev.team.application.port.outbound.summary.TeamMemberSummary
-import sharev.team.application.port.outbound.summary.TeamSummary
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.Team
-import sharev.team.domain.model.TeamType
 
 @Component
 class TeamJpaAdapter(
     private val teamRepository: TeamRepository,
-) : SaveTeamPort, LoadTeamPort, QueryTeamPort {
+) : SaveTeamPort,
+    LoadTeamPort,
+    QueryTeamPort {
 
-    override fun save(title: String?, content: String, type: TeamType): Team {
+    override fun save(team: Team): Team {
         return onUniqueViolation({ TeamException(TeamExceptionCode.DUPLICATE_TEAM_NAME) }) {
-            teamRepository.save(TeamJpaEntity(title = title, content = content, type = type))
+            teamRepository.save(team.toJpaEntity())
                 .toDomainModel()
         }
     }
 
-    override fun update(teamId: Long, title: String, content: String): Team {
-        val teamJpaEntity = teamRepository.findByIdOrNull(teamId)
+    override fun updateTitleAndContent(team: Team): Team {
+        val entity = teamRepository.findByIdOrNull(team.id)
             ?: throw TeamException(TeamExceptionCode.TEAM_NOT_FOUND)
 
-        teamJpaEntity.update(title, content)
+        entity.update(checkNotNull(team.title), checkNotNull(team.content))
 
         return onUniqueViolation({ TeamException(TeamExceptionCode.DUPLICATE_TEAM_NAME) }) {
-            teamRepository.saveAndFlush(teamJpaEntity)
+            teamRepository.saveAndFlush(entity)
                 .toDomainModel()
         }
     }
@@ -50,7 +51,7 @@ class TeamJpaAdapter(
         return teamRepository.existsById(teamId)
     }
 
-    override fun findMyTeams(accountId: Long): List<TeamSummary> {
+    override fun findMyTeams(accountId: Long): List<MyTeamSummary> {
         return teamRepository.findMyTeams(accountId)
     }
 

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
@@ -5,6 +5,7 @@ import org.hibernate.annotations.SoftDelete
 import org.hibernate.annotations.SoftDeleteType
 import sharev.common.adapter.outbound.jpa.entity.BaseTimeEntity
 import sharev.team.domain.model.TeamCertification
+import sharev.team.domain.model.TeamType
 
 @Entity
 @Table(name = "teams")
@@ -19,6 +20,10 @@ class TeamJpaEntity(
     @Column
     @Enumerated(EnumType.STRING)
     var certification: TeamCertification = TeamCertification.NONE,
+
+    @Column
+    @Enumerated(EnumType.STRING)
+    val type: TeamType,
 
     @Column(unique = true)
     var title: String,

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
@@ -26,7 +26,7 @@ class TeamJpaEntity(
     val type: TeamType,
 
     @Column(unique = true)
-    var title: String,
+    var title: String?,
 
     @Column
     var content: String,

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/entity/TeamJpaEntity.kt
@@ -18,18 +18,18 @@ class TeamJpaEntity(
     val id: Long? = null,
 
     @Column
+    var title: String?,
+
+    @Column
+    var content: String?,
+
+    @Column
     @Enumerated(EnumType.STRING)
     var certification: TeamCertification = TeamCertification.NONE,
 
     @Column
     @Enumerated(EnumType.STRING)
     val type: TeamType,
-
-    @Column(unique = true)
-    var title: String?,
-
-    @Column
-    var content: String,
 ) : BaseTimeEntity() {
 
     fun update(title: String, content: String) {

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/mapper/TeamJpaMapper.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/mapper/TeamJpaMapper.kt
@@ -3,11 +3,6 @@ package sharev.team.adapter.outbound.jpa.mapper
 import sharev.team.adapter.outbound.jpa.entity.TeamJpaEntity
 import sharev.team.domain.model.Team
 
-fun TeamJpaEntity.toDomainModel() = Team(
-    id = checkNotNull(id),
-    teamCertification = certification,
-    title = title,
-    content = content,
-    teamType = type,
-    createdAt = createdAt,
-)
+fun TeamJpaEntity.toDomainModel(): Team = Team(checkNotNull(id), title, content, certification, type, createdAt)
+
+fun Team.toJpaEntity(): TeamJpaEntity = TeamJpaEntity(id.takeIf { it != 0L }, title, content, certification, type)

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/mapper/TeamJpaMapper.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/mapper/TeamJpaMapper.kt
@@ -4,9 +4,10 @@ import sharev.team.adapter.outbound.jpa.entity.TeamJpaEntity
 import sharev.team.domain.model.Team
 
 fun TeamJpaEntity.toDomainModel() = Team(
-    id = id!!,
+    id = checkNotNull(id),
     teamCertification = certification,
     title = title,
     content = content,
+    teamType = type,
     createdAt = createdAt,
 )

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/repository/TeamRepositoryCustom.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/repository/TeamRepositoryCustom.kt
@@ -1,10 +1,10 @@
 package sharev.team.adapter.outbound.jpa.repository
 
+import sharev.team.application.port.outbound.summary.MyTeamSummary
 import sharev.team.application.port.outbound.summary.TeamMemberSummary
-import sharev.team.application.port.outbound.summary.TeamSummary
 
 interface TeamRepositoryCustom {
-    fun findMyTeams(accountId: Long): List<TeamSummary>
+    fun findMyTeams(accountId: Long): List<MyTeamSummary>
 
     fun findMyTeamMembers(teamId: Long): List<TeamMemberSummary>
 }

--- a/src/main/kotlin/sharev/team/adapter/outbound/jpa/repository/TeamRepositoryImpl.kt
+++ b/src/main/kotlin/sharev/team/adapter/outbound/jpa/repository/TeamRepositoryImpl.kt
@@ -3,8 +3,8 @@ package sharev.team.adapter.outbound.jpa.repository
 import jakarta.persistence.EntityManager
 import org.springframework.stereotype.Repository
 import sharev.member.domain.model.MemberRole
+import sharev.team.application.port.outbound.summary.MyTeamSummary
 import sharev.team.application.port.outbound.summary.TeamMemberSummary
-import sharev.team.application.port.outbound.summary.TeamSummary
 import java.time.LocalDateTime
 
 @Repository
@@ -12,7 +12,7 @@ class TeamRepositoryImpl(
     private val entityManager: EntityManager,
 ) : TeamRepositoryCustom {
 
-    override fun findMyTeams(accountId: Long): List<TeamSummary> {
+    override fun findMyTeams(accountId: Long): List<MyTeamSummary> {
         val rows = entityManager.createQuery(
             """
             select t.id, t.title, t.content, t.createdAt, m.role,
@@ -27,7 +27,7 @@ class TeamRepositoryImpl(
             .resultList
 
         return rows.map { row ->
-            TeamSummary(
+            MyTeamSummary(
                 id = row[0] as Long,
                 title = row[1] as String,
                 content = row[2] as String?,

--- a/src/main/kotlin/sharev/team/application/port/inbound/command/CreateTeamCommand.kt
+++ b/src/main/kotlin/sharev/team/application/port/inbound/command/CreateTeamCommand.kt
@@ -1,7 +1,14 @@
 package sharev.team.application.port.inbound.command
 
+import sharev.team.domain.model.TeamType
+
 data class CreateTeamCommand(
     val accountId: Long,
-    val title: String,
+    val title: String?,
     val content: String,
-)
+    val type: TeamType,
+) {
+    init {
+        require(type != TeamType.PUBLIC || !title.isNullOrBlank())
+    }
+}

--- a/src/main/kotlin/sharev/team/application/port/inbound/command/CreateTeamCommand.kt
+++ b/src/main/kotlin/sharev/team/application/port/inbound/command/CreateTeamCommand.kt
@@ -1,14 +1,18 @@
 package sharev.team.application.port.inbound.command
 
+import sharev.team.domain.exception.TeamException
+import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.TeamType
 
 data class CreateTeamCommand(
     val accountId: Long,
     val title: String?,
-    val content: String,
+    val content: String?,
     val type: TeamType,
 ) {
     init {
-        require(type != TeamType.PUBLIC || !title.isNullOrBlank())
+        if (type == TeamType.PUBLIC && (title.isNullOrBlank() || content.isNullOrBlank())) {
+            throw TeamException(TeamExceptionCode.TEAM_INFO_REQUIRED)
+        }
     }
 }

--- a/src/main/kotlin/sharev/team/application/port/inbound/result/TeamDetailResult.kt
+++ b/src/main/kotlin/sharev/team/application/port/inbound/result/TeamDetailResult.kt
@@ -6,7 +6,7 @@ import java.time.LocalDateTime
 
 data class TeamDetailResult(
     val id: Long,
-    val title: String,
+    val title: String?,
     val content: String?,
     val createdAt: LocalDateTime?,
     val headcount: Int,

--- a/src/main/kotlin/sharev/team/application/port/inbound/result/TeamInfoResult.kt
+++ b/src/main/kotlin/sharev/team/application/port/inbound/result/TeamInfoResult.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class TeamInfoResult(
     val id: Long,
-    val title: String,
+    val title: String?,
     val content: String?,
     val createdAt: LocalDateTime?,
     val memberRole: String,

--- a/src/main/kotlin/sharev/team/application/port/outbound/CheckTeamMemberPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/CheckTeamMemberPort.kt
@@ -1,6 +1,0 @@
-package sharev.team.application.port.outbound
-
-interface CheckTeamMemberPort {
-    fun isMember(accountId: Long, teamId: Long): Boolean
-    fun isAdminMember(accountId: Long, teamId: Long): Boolean
-}

--- a/src/main/kotlin/sharev/team/application/port/outbound/QueryGatheringPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/QueryGatheringPort.kt
@@ -2,6 +2,6 @@ package sharev.team.application.port.outbound
 
 import sharev.team.application.port.outbound.summary.GatheringSummary
 
-fun interface LoadGatheringSummaryPort {
-    fun loadByTeam(teamId: Long): List<GatheringSummary>
+fun interface QueryGatheringPort {
+    fun findByTeam(teamId: Long): List<GatheringSummary>
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/QueryTeamPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/QueryTeamPort.kt
@@ -1,9 +1,9 @@
 package sharev.team.application.port.outbound
 
+import sharev.team.application.port.outbound.summary.MyTeamSummary
 import sharev.team.application.port.outbound.summary.TeamMemberSummary
-import sharev.team.application.port.outbound.summary.TeamSummary
 
 interface QueryTeamPort {
-    fun findMyTeams(accountId: Long): List<TeamSummary>
+    fun findMyTeams(accountId: Long): List<MyTeamSummary>
     fun findTeamMembers(teamId: Long): List<TeamMemberSummary>
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamAdminPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamAdminPort.kt
@@ -1,5 +1,5 @@
 package sharev.team.application.port.outbound
 
-fun interface SaveTeamAdminMemberPort {
+fun interface SaveTeamAdminPort {
     fun saveTeamAdmin(teamId: Long, accountId: Long)
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamAdminPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamAdminPort.kt
@@ -1,5 +1,5 @@
 package sharev.team.application.port.outbound
 
 fun interface SaveTeamAdminPort {
-    fun saveTeamAdmin(teamId: Long, accountId: Long)
+    fun save(teamId: Long, accountId: Long)
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamPort.kt
@@ -1,9 +1,8 @@
 package sharev.team.application.port.outbound
 
 import sharev.team.domain.model.Team
-import sharev.team.domain.model.TeamType
 
 interface SaveTeamPort {
-    fun save(title: String?, content: String, type: TeamType): Team
-    fun update(teamId: Long, title: String, content: String): Team
+    fun save(team: Team): Team
+    fun updateTitleAndContent(team: Team): Team
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/SaveTeamPort.kt
@@ -1,8 +1,9 @@
 package sharev.team.application.port.outbound
 
 import sharev.team.domain.model.Team
+import sharev.team.domain.model.TeamType
 
 interface SaveTeamPort {
-    fun save(title: String, content: String): Team
+    fun save(title: String?, content: String, type: TeamType): Team
     fun update(teamId: Long, title: String, content: String): Team
 }

--- a/src/main/kotlin/sharev/team/application/port/outbound/TeamAccessPort.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/TeamAccessPort.kt
@@ -1,0 +1,6 @@
+package sharev.team.application.port.outbound
+
+interface TeamAccessPort {
+    fun hasAccess(accountId: Long, teamId: Long): Boolean
+    fun canManage(accountId: Long, teamId: Long): Boolean
+}

--- a/src/main/kotlin/sharev/team/application/port/outbound/summary/MyTeamSummary.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/summary/MyTeamSummary.kt
@@ -2,7 +2,7 @@ package sharev.team.application.port.outbound.summary
 
 import java.time.LocalDateTime
 
-data class TeamSummary(
+data class MyTeamSummary(
     val id: Long,
     val title: String?,
     val content: String?,

--- a/src/main/kotlin/sharev/team/application/port/outbound/summary/TeamSummary.kt
+++ b/src/main/kotlin/sharev/team/application/port/outbound/summary/TeamSummary.kt
@@ -4,7 +4,7 @@ import java.time.LocalDateTime
 
 data class TeamSummary(
     val id: Long,
-    val title: String,
+    val title: String?,
     val content: String?,
     val createdAt: LocalDateTime?,
     val memberRole: String,

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -14,6 +14,7 @@ import sharev.team.application.port.inbound.usecase.UpdateTeamInfoUseCase
 import sharev.team.application.port.outbound.*
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
+import sharev.team.domain.model.TeamType
 
 @Service
 @Transactional(readOnly = true)
@@ -57,8 +58,14 @@ class TeamService(
             throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE)
         }
 
-        val team = saveTeamPort.update(command.teamId, command.title, command.content)
-        return TeamUpdateInfoResult(team.title, team.content)
+        val team = loadTeamPort.load(command.teamId)
+
+        if (team.teamType == TeamType.PERSONAL) {
+            throw TeamException(TeamExceptionCode.PERSONAL_TEAM_NOT_MODIFIABLE)
+        }
+
+        val updateTeam = saveTeamPort.update(command.teamId, command.title, command.content)
+        return TeamUpdateInfoResult(updateTeam.title, updateTeam.content)
     }
 
     override fun getTeamDetail(accountId: Long, teamId: Long): TeamDetailResult {

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -15,7 +15,6 @@ import sharev.team.application.port.outbound.*
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.Team
-import sharev.team.domain.model.TeamCertification
 
 @Service
 @Transactional(readOnly = true)
@@ -33,19 +32,8 @@ class TeamService(
 
     @Transactional
     override fun create(command: CreateTeamCommand): CreateTeamResult {
-        val team = saveTeamPort.save(
-            Team(
-                0L,
-                command.title,
-                command.content,
-                TeamCertification.NONE,
-                command.type,
-                null
-            )
-        )
-
+        val team = saveTeamPort.save(Team.create(command.title, command.content, command.type))
         saveTeamAdminPort.save(team.id, command.accountId)
-
         return team.toCreateTeamResult()
     }
 

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -21,8 +21,8 @@ class TeamService(
     private val saveTeamPort: SaveTeamPort,
     private val loadTeamPort: LoadTeamPort,
     private val queryTeamPort: QueryTeamPort,
-    private val saveTeamAdminMemberPort: SaveTeamAdminMemberPort,
-    private val checkTeamMemberPort: CheckTeamMemberPort,
+    private val saveTeamAdminPort: SaveTeamAdminPort,
+    private val teamAccessPort: TeamAccessPort,
     private val loadGatheringSummaryPort: LoadGatheringSummaryPort,
 ) : CreateTeamUseCase,
     GetMyTeamsUseCase,
@@ -32,7 +32,7 @@ class TeamService(
     @Transactional
     override fun create(command: CreateTeamCommand): CreateTeamResult {
         val team = saveTeamPort.save(command.title, command.content)
-        saveTeamAdminMemberPort.saveTeamAdmin(
+        saveTeamAdminPort.saveTeamAdmin(
             team.id,
             command.accountId,
         )
@@ -56,8 +56,8 @@ class TeamService(
 
     @Transactional
     override fun updateTeamInfo(command: UpdateTeamInfoCommand): TeamUpdateInfoResult {
-        if (!checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER)
+        if (!teamAccessPort.canManage(command.accountId, command.teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE)
         }
 
         val team = saveTeamPort.update(command.teamId, command.title, command.content)
@@ -65,8 +65,8 @@ class TeamService(
     }
 
     override fun getTeamDetail(accountId: Long, teamId: Long): TeamDetailResult {
-        if (!checkTeamMemberPort.isMember(accountId, teamId)) {
-            throw TeamException(TeamExceptionCode.NOT_TEAM_MEMBER)
+        if (!teamAccessPort.hasAccess(accountId, teamId)) {
+            throw TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS)
         }
 
         val team = loadTeamPort.load(teamId)

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -31,11 +31,8 @@ class TeamService(
 
     @Transactional
     override fun create(command: CreateTeamCommand): CreateTeamResult {
-        val team = saveTeamPort.save(command.title, command.content)
-        saveTeamAdminPort.saveTeamAdmin(
-            team.id,
-            command.accountId,
-        )
+        val team = saveTeamPort.save(command.title, command.content, command.type)
+        saveTeamAdminPort.saveTeamAdmin(team.id, command.accountId)
 
         return team.toCreateTeamResult()
     }

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -14,7 +14,8 @@ import sharev.team.application.port.inbound.usecase.UpdateTeamInfoUseCase
 import sharev.team.application.port.outbound.*
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
-import sharev.team.domain.model.TeamType
+import sharev.team.domain.model.Team
+import sharev.team.domain.model.TeamCertification
 
 @Service
 @Transactional(readOnly = true)
@@ -24,7 +25,7 @@ class TeamService(
     private val queryTeamPort: QueryTeamPort,
     private val saveTeamAdminPort: SaveTeamAdminPort,
     private val teamAccessPort: TeamAccessPort,
-    private val loadGatheringSummaryPort: LoadGatheringSummaryPort,
+    private val queryGatheringPort: QueryGatheringPort,
 ) : CreateTeamUseCase,
     GetMyTeamsUseCase,
     GetTeamDetailUseCase,
@@ -32,8 +33,18 @@ class TeamService(
 
     @Transactional
     override fun create(command: CreateTeamCommand): CreateTeamResult {
-        val team = saveTeamPort.save(command.title, command.content, command.type)
-        saveTeamAdminPort.saveTeamAdmin(team.id, command.accountId)
+        val team = saveTeamPort.save(
+            Team(
+                0L,
+                command.title,
+                command.content,
+                TeamCertification.NONE,
+                command.type,
+                null
+            )
+        )
+
+        saveTeamAdminPort.save(team.id, command.accountId)
 
         return team.toCreateTeamResult()
     }
@@ -60,12 +71,9 @@ class TeamService(
 
         val team = loadTeamPort.load(command.teamId)
 
-        if (team.teamType == TeamType.PERSONAL) {
-            throw TeamException(TeamExceptionCode.PERSONAL_TEAM_NOT_MODIFIABLE)
-        }
+        val updatedTeam = saveTeamPort.updateTitleAndContent(team.updateInfo(command.title, command.content))
 
-        val updateTeam = saveTeamPort.update(command.teamId, command.title, command.content)
-        return TeamUpdateInfoResult(checkNotNull(updateTeam.title), updateTeam.content)
+        return TeamUpdateInfoResult(checkNotNull(updatedTeam.title), checkNotNull(updatedTeam.content))
     }
 
     override fun getTeamDetail(accountId: Long, teamId: Long): TeamDetailResult {
@@ -74,7 +82,7 @@ class TeamService(
         }
 
         val team = loadTeamPort.load(teamId)
-        val gatherings = loadGatheringSummaryPort.loadByTeam(teamId)
+        val gatherings = queryGatheringPort.findByTeam(teamId)
         val members = queryTeamPort.findTeamMembers(teamId)
 
         return TeamDetailResult(
@@ -83,7 +91,7 @@ class TeamService(
             content = team.content,
             createdAt = team.createdAt,
             headcount = members.size,
-            certification = team.teamCertification,
+            certification = team.certification,
             gatherings = gatherings.map {
                 GatheringInfoResult(it.title, it.startAt, it.endAt, it.place)
             },

--- a/src/main/kotlin/sharev/team/application/service/TeamService.kt
+++ b/src/main/kotlin/sharev/team/application/service/TeamService.kt
@@ -65,7 +65,7 @@ class TeamService(
         }
 
         val updateTeam = saveTeamPort.update(command.teamId, command.title, command.content)
-        return TeamUpdateInfoResult(updateTeam.title, updateTeam.content)
+        return TeamUpdateInfoResult(checkNotNull(updateTeam.title), updateTeam.content)
     }
 
     override fun getTeamDetail(accountId: Long, teamId: Long): TeamDetailResult {

--- a/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
+++ b/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
@@ -7,13 +7,13 @@ enum class TeamExceptionCode(
     override val category: ExceptionCategory,
     override val message: String,
 ) : ExceptionCode {
-    NOT_TEAM_MEMBER(
+    UNAUTHORIZED_TEAM_ACCESS(
         ExceptionCategory.FORBIDDEN,
-        "해당 팀의 멤버가 아닙니다."
+        "해당 팀에 대한 접근 권한이 없습니다."
     ),
-    NOT_TEAM_ADMIN_MEMBER(
+    UNAUTHORIZED_TEAM_MANAGE(
         ExceptionCategory.FORBIDDEN,
-        "해당 팀의 어드민이 아닙니다."
+        "해당 팀에 대한 관리 권한이 없습니다."
     ),
     DUPLICATE_TEAM_NAME(
         ExceptionCategory.CONFLICT,

--- a/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
+++ b/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
@@ -23,9 +23,9 @@ enum class TeamExceptionCode(
         ExceptionCategory.NOT_FOUND,
         "팀이 존재하지 않습니다."
     ),
-    PERSONAL_TEAM_NOT_MODIFIABLE(
+    NOT_MODIFIABLE_TEAM(
         ExceptionCategory.FORBIDDEN,
-        "개인 팀은 수정할 수 없습니다."
+        "수정 가능한 팀 형태가 아닙니다."
     ),
     TEAM_INFO_REQUIRED(
         ExceptionCategory.BAD_REQUEST,

--- a/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
+++ b/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
@@ -27,4 +27,8 @@ enum class TeamExceptionCode(
         ExceptionCategory.FORBIDDEN,
         "개인 팀은 수정할 수 없습니다."
     ),
+    TEAM_INFO_REQUIRED(
+        ExceptionCategory.BAD_REQUEST,
+        "제목과 내용은 비워둘 수 없습니다."
+    ),
 }

--- a/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
+++ b/src/main/kotlin/sharev/team/domain/exception/TeamExceptionCode.kt
@@ -23,4 +23,8 @@ enum class TeamExceptionCode(
         ExceptionCategory.NOT_FOUND,
         "팀이 존재하지 않습니다."
     ),
+    PERSONAL_TEAM_NOT_MODIFIABLE(
+        ExceptionCategory.FORBIDDEN,
+        "개인 팀은 수정할 수 없습니다."
+    ),
 }

--- a/src/main/kotlin/sharev/team/domain/model/Team.kt
+++ b/src/main/kotlin/sharev/team/domain/model/Team.kt
@@ -6,7 +6,7 @@ data class Team(
     val id: Long,
     val teamCertification: TeamCertification,
     val teamType: TeamType,
-    val title: String,
+    val title: String?,
     val content: String,
     val createdAt: LocalDateTime?,
 ) {

--- a/src/main/kotlin/sharev/team/domain/model/Team.kt
+++ b/src/main/kotlin/sharev/team/domain/model/Team.kt
@@ -1,13 +1,22 @@
 package sharev.team.domain.model
 
+import sharev.team.domain.exception.TeamException
+import sharev.team.domain.exception.TeamExceptionCode
 import java.time.LocalDateTime
 
 data class Team(
     val id: Long,
-    val teamCertification: TeamCertification,
-    val teamType: TeamType,
     val title: String?,
-    val content: String,
+    val content: String?,
+    val certification: TeamCertification,
+    val type: TeamType,
     val createdAt: LocalDateTime?,
 ) {
+    fun updateInfo(title: String, content: String): Team {
+        if (type != TeamType.PUBLIC) {
+            throw TeamException(TeamExceptionCode.NOT_MODIFIABLE_TEAM)
+        }
+
+        return copy(title = title, content = content)
+    }
 }

--- a/src/main/kotlin/sharev/team/domain/model/Team.kt
+++ b/src/main/kotlin/sharev/team/domain/model/Team.kt
@@ -12,6 +12,12 @@ data class Team(
     val type: TeamType,
     val createdAt: LocalDateTime?,
 ) {
+    companion object {
+        fun create(title: String?, content: String?, type: TeamType): Team {
+            return Team(0L, title, content, TeamCertification.NONE, type, null)
+        }
+    }
+
     fun updateInfo(title: String, content: String): Team {
         if (type != TeamType.PUBLIC) {
             throw TeamException(TeamExceptionCode.NOT_MODIFIABLE_TEAM)

--- a/src/main/kotlin/sharev/team/domain/model/Team.kt
+++ b/src/main/kotlin/sharev/team/domain/model/Team.kt
@@ -5,6 +5,7 @@ import java.time.LocalDateTime
 data class Team(
     val id: Long,
     val teamCertification: TeamCertification,
+    val teamType: TeamType,
     val title: String,
     val content: String,
     val createdAt: LocalDateTime?,

--- a/src/main/kotlin/sharev/team/domain/model/Team.kt
+++ b/src/main/kotlin/sharev/team/domain/model/Team.kt
@@ -23,6 +23,10 @@ data class Team(
             throw TeamException(TeamExceptionCode.NOT_MODIFIABLE_TEAM)
         }
 
+        if (title.isBlank() || content.isBlank()) {
+            throw TeamException(TeamExceptionCode.TEAM_INFO_REQUIRED)
+        }
+
         return copy(title = title, content = content)
     }
 }

--- a/src/main/kotlin/sharev/team/domain/model/TeamType.kt
+++ b/src/main/kotlin/sharev/team/domain/model/TeamType.kt
@@ -1,0 +1,6 @@
+package sharev.team.domain.model
+
+enum class TeamType {
+    PUBLIC,
+    PERSONAL,
+}

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -39,11 +39,13 @@ CREATE TABLE teams
     team_id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     certification VARCHAR(20) NOT NULL, -- 'NONE', 'CERTIFICATED'
     type          VARCHAR(20) NOT NULL, -- 'PUBLIC', 'PERSONAL'
-    title         TEXT        NOT NULL,
+    title         TEXT        NULL,
     content       TEXT        NOT NULL,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    deleted_at    TIMESTAMPTZ NULL
+    deleted_at    TIMESTAMPTZ NULL,
+
+    CONSTRAINT ck_teams_public_title CHECK (type <> 'PUBLIC' OR (title IS NOT NULL AND btrim(title) <> ''))
 );
 
 CREATE UNIQUE INDEX uk_teams_title_active ON teams (title) WHERE deleted_at IS NULL;

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -40,7 +40,7 @@ CREATE TABLE teams
     certification VARCHAR(20) NOT NULL, -- 'NONE', 'CERTIFICATED'
     type          VARCHAR(20) NOT NULL, -- 'PUBLIC', 'PERSONAL'
     title         TEXT        NULL,
-    content       TEXT        NOT NULL,
+    content       TEXT        NULL,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     deleted_at    TIMESTAMPTZ NULL,

--- a/src/main/resources/ddl.sql
+++ b/src/main/resources/ddl.sql
@@ -38,6 +38,7 @@ CREATE TABLE teams
 (
     team_id       BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     certification VARCHAR(20) NOT NULL, -- 'NONE', 'CERTIFICATED'
+    type          VARCHAR(20) NOT NULL, -- 'PUBLIC', 'PERSONAL'
     title         TEXT        NOT NULL,
     content       TEXT        NOT NULL,
     created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),

--- a/src/main/resources/dml.sql
+++ b/src/main/resources/dml.sql
@@ -1,23 +1,32 @@
 -- ============================================
 -- Accounts (독립적 테이블)
 -- ============================================
-INSERT INTO "accounts" ("account_id", "role", "name", "email", "created_at", "updated_at")
+-- handle: PUBLIC 팀 생성/초대에 필요한 VERIFIED 권한의 전제 (^[a-zA-Z0-9_]{4,20}$, UNIQUE)
+INSERT INTO "accounts" ("account_id", "role", "name", "email", "handle", "created_at", "updated_at")
     OVERRIDING SYSTEM VALUE
-VALUES (1, 'ADMIN', '관리자', 'admin@example.com', NOW(), NOW()),
-       (2, 'USER', '홍길동', 'hong@example.com', NOW(), NOW()),
-       (3, 'USER', '김철수', 'kim@example.com', NOW(), NOW()),
-       (4, 'USER', '이영희', 'lee@example.com', NOW(), NOW()),
-       (5, 'USER', '박민수', 'park@example.com', NOW(), NOW());
+VALUES (1, 'ADMIN', '관리자', 'admin@example.com', 'admin', NOW(), NOW()),
+       (2, 'USER', '홍길동', 'hong@example.com', 'honggildong', NOW(), NOW()),
+       (3, 'USER', '김철수', 'kim@example.com', 'kimchulsoo', NOW(), NOW()),
+       (4, 'USER', '이영희', 'lee@example.com', 'leeyounghee', NOW(), NOW()),
+       (5, 'USER', '박민수', 'park@example.com', 'parkminsoo', NOW(), NOW());
 
 -- ============================================
 -- Teams (독립적 테이블)
+--   - PUBLIC  : 사용자가 웹에서 생성한 공개 팀 (title/content 필수)
+--   - PERSONAL: 회원가입 시 계정당 1개씩 자동 생성되는 개인 팀 (title NULL, content '')
 -- ============================================
-INSERT INTO "teams" ("team_id", "certification", "title", "content", "created_at", "updated_at")
+INSERT INTO "teams" ("team_id", "certification", "type", "title", "content", "created_at", "updated_at")
     OVERRIDING SYSTEM VALUE
-VALUES (1, 'CERTIFICATED', '개발팀', '백엔드 개발을 담당하는 팀입니다.', NOW(), NOW()),
-       (2, 'NONE', '디자인팀', 'UI/UX 디자인을 담당하는 팀입니다.', NOW(), NOW()),
-       (3, 'CERTIFICATED', '기획팀', '서비스 기획을 담당하는 팀입니다.', NOW(), NOW()),
-       (4, 'NONE', '마케팅팀', '마케팅을 담당하는 팀입니다.', NOW(), NOW());
+VALUES (1, 'CERTIFICATED', 'PUBLIC', '개발팀', '백엔드 개발을 담당하는 팀입니다.', NOW(), NOW()),
+       (2, 'NONE', 'PUBLIC', '디자인팀', 'UI/UX 디자인을 담당하는 팀입니다.', NOW(), NOW()),
+       (3, 'CERTIFICATED', 'PUBLIC', '기획팀', '서비스 기획을 담당하는 팀입니다.', NOW(), NOW()),
+       (4, 'NONE', 'PUBLIC', '마케팅팀', '마케팅을 담당하는 팀입니다.', NOW(), NOW()),
+       -- 개인 팀: 각 계정(1~5)의 회원가입 시 자동 생성된 팀 (title NULL, content '')
+       (5, 'NONE', 'PERSONAL', NULL, '', NOW(), NOW()),
+       (6, 'NONE', 'PERSONAL', NULL, '', NOW(), NOW()),
+       (7, 'NONE', 'PERSONAL', NULL, '', NOW(), NOW()),
+       (8, 'NONE', 'PERSONAL', NULL, '', NOW(), NOW()),
+       (9, 'NONE', 'PERSONAL', NULL, '', NOW(), NOW());
 
 -- ============================================
 -- OAuth Accounts (accounts 참조)
@@ -40,7 +49,14 @@ VALUES (1, 1, 1, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
        (4, 2, 2, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
        (5, 2, 4, 'INVITE', 'COMMON', NOW(), NOW()),
        (6, 3, 1, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
-       (7, 3, 5, 'ACTIVATE', 'COMMON', NOW(), NOW());
+       (7, 3, 5, 'ACTIVATE', 'COMMON', NOW(), NOW()),
+       (8, 4, 4, 'ACTIVATE', 'ADMIN', NOW(), NOW()), -- 마케팅팀 생성자(모든 PUBLIC 팀은 생성 시 ADMIN 멤버가 생김)
+       -- 개인 팀 소유자: 본인 개인 팀(team 5~9)의 유일한 멤버, 항상 ACTIVATE/ADMIN
+       (9, 5, 1, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
+       (10, 6, 2, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
+       (11, 7, 3, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
+       (12, 8, 4, 'ACTIVATE', 'ADMIN', NOW(), NOW()),
+       (13, 9, 5, 'ACTIVATE', 'ADMIN', NOW(), NOW());
 
 -- ============================================
 -- Gatherings (teams 참조)

--- a/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
+++ b/src/test/kotlin/sharev/account/application/service/AccountServiceTest.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import sharev.account.application.port.inbound.command.DeleteAccountCommand
 import sharev.account.application.port.inbound.command.UpdateAccountInfoCommand
-import sharev.account.application.port.outbound.CheckHandleDuplicatedPort
 import sharev.account.application.port.outbound.DeleteAccountPort
 import sharev.account.application.port.outbound.UpdateAccountHandlePort
 import sharev.account.application.port.outbound.UpdateAccountPort
@@ -26,14 +25,12 @@ class AccountServiceTest {
     private val deleteAccountPort = mock(DeleteAccountPort::class.java)
     private val publishEventPort = mock(PublishEventPort::class.java)
     private val updateAccountHandlePort = mock(UpdateAccountHandlePort::class.java)
-    private val checkHandleDuplicatedPort = mock(CheckHandleDuplicatedPort::class.java)
 
     private val accountService = AccountService(
         updateAccountPort,
         deleteAccountPort,
         publishEventPort,
         updateAccountHandlePort,
-        checkHandleDuplicatedPort,
     )
 
     // ───────────── updateAccountInfo ─────────────

--- a/src/test/kotlin/sharev/account/application/service/OAuthAccountServiceTest.kt
+++ b/src/test/kotlin/sharev/account/application/service/OAuthAccountServiceTest.kt
@@ -17,18 +17,21 @@ import sharev.account.domain.model.Account
 import sharev.account.domain.model.AccountRole
 import sharev.account.domain.model.OAuthAccount
 import sharev.account.domain.model.OAuthProvider
+import sharev.common.application.port.outbound.PublishEventPort
 
 class OAuthAccountServiceTest {
     private val loadOAuthAccountPort = mock(LoadOAuthAccountPort::class.java)
     private val saveOAuthAccountPort = mock(SaveOAuthAccountPort::class.java)
     private val loadAccountPort = mock(LoadAccountPort::class.java)
     private val saveAccountPort = mock(SaveAccountPort::class.java)
+    private val publishEventPort = mock(PublishEventPort::class.java)
 
     private val oAuthAccountService = OAuthAccountService(
         loadOAuthAccountPort,
         saveOAuthAccountPort,
         loadAccountPort,
         saveAccountPort,
+        publishEventPort,
     )
 
     // ───────────── login ─────────────

--- a/src/test/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringControllerTest.kt
+++ b/src/test/kotlin/sharev/gathering/adapter/inbound/web/controller/GatheringControllerTest.kt
@@ -258,7 +258,7 @@ class GatheringControllerTest : ControllerTestSupport() {
             LocalDateTime.of(2025, 3, 19, 23, 59),
         )
 
-        willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+        willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
             .given(mockBean<CreateGatheringUseCase>()).create(
                 CreateGatheringCommand(
                     1L,
@@ -325,7 +325,7 @@ class GatheringControllerTest : ControllerTestSupport() {
         val teamId = 1L
 
         given(mockBean<GetTeamGatheringUseCase>().getTeamGatherings(1L, teamId))
-            .willThrow(TeamException(TeamExceptionCode.NOT_TEAM_MEMBER))
+            .willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS))
 
         val request = RestDocumentationRequestBuilders.get("/teams/{teamId}/gatherings", teamId)
             .contentType(MediaType.APPLICATION_JSON)
@@ -489,7 +489,7 @@ class GatheringControllerTest : ControllerTestSupport() {
                     requireNotNull(dto.registerEndAt),
                 )
             )
-        ).willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+        ).willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
 
         val request = RestDocumentationRequestBuilders.patch(
             "/teams/{teamId}/gatherings/{gatheringId}",
@@ -550,7 +550,7 @@ class GatheringControllerTest : ControllerTestSupport() {
         val teamId = 1L
         val gatheringId = UUID.randomUUID()
 
-        willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+        willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
             .given(mockBean<DeleteGatheringUseCase>())
             .delete(1L, teamId, gatheringId)
 

--- a/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
+++ b/src/test/kotlin/sharev/gathering/application/service/GatheringParticipantServiceTest.kt
@@ -14,18 +14,14 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import sharev.gathering.application.port.inbound.command.CreateGatheringCommand
 import sharev.gathering.application.port.inbound.command.UpdateGatheringCommand
-import sharev.gathering.application.port.outbound.CheckGatheringParticipantPort
-import sharev.gathering.application.port.outbound.LoadGatheringPort
-import sharev.gathering.application.port.outbound.LoadIntroduceTemplatePort
-import sharev.gathering.application.port.outbound.LoadParticipatedGatheringsPort
-import sharev.gathering.application.port.outbound.SaveGatheringPort
+import sharev.gathering.application.port.outbound.*
 import sharev.gathering.domain.exception.GatheringException
 import sharev.gathering.domain.exception.GatheringExceptionCode
 import sharev.gathering.domain.model.Gathering
 import sharev.gathering.domain.model.GatheringVisible
 import sharev.gathering.domain.model.IntroduceTemplate
 import sharev.gathering.domain.model.IntroduceTemplateContent
-import sharev.team.application.port.outbound.CheckTeamMemberPort
+import sharev.team.application.port.outbound.TeamAccessPort
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import java.time.LocalDateTime
@@ -36,7 +32,7 @@ class GatheringParticipantServiceTest {
     private val saveGatheringPort = mock(SaveGatheringPort::class.java)
     private val loadGatheringPort = mock(LoadGatheringPort::class.java)
     private val loadIntroduceTemplatePort = mock(LoadIntroduceTemplatePort::class.java)
-    private val checkTeamMemberPort = mock(CheckTeamMemberPort::class.java)
+    private val teamAccessPort = mock(TeamAccessPort::class.java)
     private val loadParticipatedGatheringsPort = mock(LoadParticipatedGatheringsPort::class.java)
 
     private val gatheringParticipantService = GatheringService(
@@ -44,7 +40,7 @@ class GatheringParticipantServiceTest {
         saveGatheringPort,
         loadGatheringPort,
         loadIntroduceTemplatePort,
-        checkTeamMemberPort,
+        teamAccessPort,
         loadParticipatedGatheringsPort,
     )
 
@@ -55,13 +51,13 @@ class GatheringParticipantServiceTest {
     fun create_throwsException_whenNotAdmin() {
         val command = createGatheringCommand()
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(false)
+        given(teamAccessPort.canManage(command.accountId, command.teamId)).willReturn(false)
 
         assertThatThrownBy { gatheringParticipantService.create(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveGatheringPort).shouldHaveNoInteractions()
@@ -73,7 +69,7 @@ class GatheringParticipantServiceTest {
         val command = createGatheringCommand()
         val savedGathering = gathering(id = UUID.randomUUID(), command = command)
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(true)
+        given(teamAccessPort.canManage(command.accountId, command.teamId)).willReturn(true)
         given(saveGatheringPort.save(gathering(Gathering.NEW_ID, command))).willReturn(savedGathering)
 
         val result = gatheringParticipantService.create(command)
@@ -160,13 +156,13 @@ class GatheringParticipantServiceTest {
         val accountId = 1L
         val teamId = 2L
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { gatheringParticipantService.getTeamGatherings(accountId, teamId) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS.name)
             })
 
         then(loadGatheringPort).shouldHaveNoInteractions()
@@ -182,7 +178,7 @@ class GatheringParticipantServiceTest {
             gathering(id = UUID.randomUUID(), teamId = teamId, title = "행사2"),
         )
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(true)
         given(loadGatheringPort.loadAllByTeam(teamId)).willReturn(gatheringList)
 
         val result = gatheringParticipantService.getTeamGatherings(accountId, teamId)
@@ -201,13 +197,13 @@ class GatheringParticipantServiceTest {
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { gatheringParticipantService.getTeamGathering(accountId, teamId, gatheringId) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS.name)
             })
 
         then(loadGatheringPort).shouldHaveNoInteractions()
@@ -222,7 +218,7 @@ class GatheringParticipantServiceTest {
         val gatheringId = UUID.randomUUID()
         val gatheringInOtherTeam = gathering(gatheringId, teamId = otherTeamId)
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(true)
         given(loadGatheringPort.load(gatheringId)).willReturn(gatheringInOtherTeam)
 
         assertThatThrownBy { gatheringParticipantService.getTeamGathering(accountId, teamId, gatheringId) }
@@ -241,7 +237,7 @@ class GatheringParticipantServiceTest {
         val gatheringId = UUID.randomUUID()
         val existingGathering = gathering(gatheringId, teamId = teamId)
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(true)
         given(loadGatheringPort.load(gatheringId)).willReturn(existingGathering)
 
         val result = gatheringParticipantService.getTeamGathering(accountId, teamId, gatheringId)
@@ -257,13 +253,13 @@ class GatheringParticipantServiceTest {
     fun update_throwsException_whenNotAdmin() {
         val command = updateGatheringCommand()
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(false)
+        given(teamAccessPort.canManage(command.accountId, command.teamId)).willReturn(false)
 
         assertThatThrownBy { gatheringParticipantService.update(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveGatheringPort).should(never()).update(any())
@@ -276,7 +272,7 @@ class GatheringParticipantServiceTest {
         val updatedGathering = gathering(command.gatheringId, teamId = command.teamId, title = command.title)
         val captor = argumentCaptor<Gathering>()
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId)).willReturn(true)
+        given(teamAccessPort.canManage(command.accountId, command.teamId)).willReturn(true)
         given(saveGatheringPort.update(any())).willReturn(updatedGathering)
 
         val result = gatheringParticipantService.update(command)
@@ -309,13 +305,13 @@ class GatheringParticipantServiceTest {
         val teamId = 2L
         val gatheringId = UUID.randomUUID()
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { gatheringParticipantService.delete(accountId, teamId, gatheringId) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveGatheringPort).should(never()).softDelete(any())
@@ -330,7 +326,7 @@ class GatheringParticipantServiceTest {
         val gatheringId = UUID.randomUUID()
         val gatheringInOtherTeam = gathering(gatheringId, teamId = otherTeamId)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadGatheringPort.load(gatheringId)).willReturn(gatheringInOtherTeam)
 
         assertThatThrownBy { gatheringParticipantService.delete(accountId, teamId, gatheringId) }
@@ -351,7 +347,7 @@ class GatheringParticipantServiceTest {
         val gatheringId = UUID.randomUUID()
         val existingGathering = gathering(gatheringId, teamId = teamId)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadGatheringPort.load(gatheringId)).willReturn(existingGathering)
 
         val result = gatheringParticipantService.delete(accountId, teamId, gatheringId)

--- a/src/test/kotlin/sharev/member/adapter/inbound/web/controller/MemberControllerTest.kt
+++ b/src/test/kotlin/sharev/member/adapter/inbound/web/controller/MemberControllerTest.kt
@@ -75,9 +75,9 @@ class MemberControllerTest : ControllerTestSupport() {
     @DisplayName("멤버 초대")
     fun invite() {
         val teamId = 1L
-        val dto = InviteMemberRequest("newuser@test.com")
+        val dto = InviteMemberRequest("new+user")
 
-        given(mockBean<InviteMemberUseCase>().invite(InviteMemberCommand(1L, teamId, dto.email)))
+        given(mockBean<InviteMemberUseCase>().invite(InviteMemberCommand(1L, teamId, dto.handle)))
             .willReturn(InviteMemberResult(2L, MemberRole.COMMON, MemberStatus.INVITE))
 
         val request = RestDocumentationRequestBuilders.post("/teams/{teamId}/members", teamId)
@@ -86,16 +86,16 @@ class MemberControllerTest : ControllerTestSupport() {
 
         mockMvc.perform(request)
             .andDo(print())
-            .andExpect(status().isCreated())
+            .andExpect(status().isOk())
             .andDo(
                 documentResource(
                     "inviteMember",
                     resource(
                         ResourceSnippetParameters.builder()
                             .summary("멤버 초대")
-                            .description("이메일로 팀에 멤버를 초대합니다. 팀 관리자만 초대할 수 있습니다. 초대된 멤버는 INVITE 상태로 생성됩니다.")
+                            .description("handle로 팀에 멤버를 초대합니다. 팀 관리자만 초대할 수 있습니다. 초대된 멤버는 INVITE 상태로 생성됩니다.")
                             .pathParameters(parameterWithName("teamId").description("팀 ID"))
-                            .requestFields(fieldWithPath("email").type(STRING).description("초대할 사용자의 이메일"))
+                            .requestFields(fieldWithPath("handle").type(STRING).description("초대할 사용자의 handle"))
                             .responseFields(
                                 fieldWithPath("memberId").type(NUMBER).description("생성된 멤버 ID"),
                                 fieldWithPath("role").type(STRING).description("역할 (ADMIN, COMMON)"),
@@ -116,8 +116,8 @@ class MemberControllerTest : ControllerTestSupport() {
         val teamId = 1L
         val dto = InviteMemberRequest("newuser@test.com")
 
-        given(mockBean<InviteMemberUseCase>().invite(InviteMemberCommand(1L, teamId, dto.email)))
-            .willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+        given(mockBean<InviteMemberUseCase>().invite(InviteMemberCommand(1L, teamId, dto.handle)))
+            .willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
 
         val request = RestDocumentationRequestBuilders.post("/teams/{teamId}/members", teamId)
             .content(objectMapper.writeValueAsString(dto))
@@ -247,7 +247,7 @@ class MemberControllerTest : ControllerTestSupport() {
         val dto = UpdateMemberRoleRequest(role)
 
         given(mockBean<UpdateMemberRoleUseCase>().updateRole(UpdateMemberRoleCommand(1L, teamId, memberId, role)))
-            .willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+            .willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
 
         val request = RestDocumentationRequestBuilders
             .patch("/teams/{teamId}/members/{memberId}/role", teamId, memberId)
@@ -302,7 +302,7 @@ class MemberControllerTest : ControllerTestSupport() {
         val memberId = 2L
 
         given(mockBean<RemoveMemberUseCase>().removeMember(RemoveMemberCommand(1L, teamId, memberId)))
-            .willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+            .willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
 
         val request = RestDocumentationRequestBuilders.delete("/teams/{teamId}/members/{memberId}", teamId, memberId)
             .contentType(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/sharev/member/application/service/MemberServiceTest.kt
+++ b/src/test/kotlin/sharev/member/application/service/MemberServiceTest.kt
@@ -8,23 +8,15 @@ import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
-import sharev.member.application.port.inbound.command.AcceptInvitationCommand
-import sharev.member.application.port.inbound.command.GetMembersCommand
-import sharev.member.application.port.inbound.command.InviteMemberCommand
-import sharev.member.application.port.inbound.command.LeaveTeamCommand
-import sharev.member.application.port.inbound.command.RemoveMemberCommand
-import sharev.member.application.port.inbound.command.UpdateMemberRoleCommand
-import sharev.member.application.port.outbound.DeleteMemberPort
-import sharev.member.application.port.outbound.LoadAccountForMemberPort
-import sharev.member.application.port.outbound.LoadMemberPort
-import sharev.member.application.port.outbound.SaveMemberPort
+import sharev.member.application.port.inbound.command.*
+import sharev.member.application.port.outbound.*
 import sharev.member.domain.exception.MemberException
 import sharev.member.domain.exception.MemberExceptionCode
 import sharev.member.domain.model.Member
 import sharev.member.domain.model.MemberRole
 import sharev.member.domain.model.MemberStatus
-import sharev.team.application.port.outbound.CheckTeamMemberPort
 import sharev.team.application.port.outbound.LoadTeamPort
+import sharev.team.application.port.outbound.TeamAccessPort
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 
@@ -34,7 +26,8 @@ class MemberServiceTest {
     private val saveMemberPort = mock(SaveMemberPort::class.java)
     private val deleteMemberPort = mock(DeleteMemberPort::class.java)
     private val loadAccountForMemberPort = mock(LoadAccountForMemberPort::class.java)
-    private val checkTeamMemberPort = mock(CheckTeamMemberPort::class.java)
+    private val teamAccessPort = mock(TeamAccessPort::class.java)
+    private val checkMemberPort = mock(CheckMemberPort::class.java)
 
     private val memberService = MemberService(
         loadTeamPort,
@@ -42,7 +35,8 @@ class MemberServiceTest {
         saveMemberPort,
         deleteMemberPort,
         loadAccountForMemberPort,
-        checkTeamMemberPort,
+        teamAccessPort,
+        checkMemberPort,
     )
 
     // ───────────── isAdmin ─────────────
@@ -58,7 +52,7 @@ class MemberServiceTest {
         val result = memberService.isAdmin(teamId, accountId)
 
         assertThat(result).isFalse()
-        then(checkTeamMemberPort).shouldHaveNoInteractions()
+        then(teamAccessPort).shouldHaveNoInteractions()
     }
 
     @Test
@@ -68,7 +62,7 @@ class MemberServiceTest {
         val accountId = 10L
 
         given(loadTeamPort.exists(teamId)).willReturn(true)
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
 
         val result = memberService.isAdmin(teamId, accountId)
 
@@ -82,7 +76,7 @@ class MemberServiceTest {
         val accountId = 10L
 
         given(loadTeamPort.exists(teamId)).willReturn(true)
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(false)
 
         val result = memberService.isAdmin(teamId, accountId)
 
@@ -98,13 +92,13 @@ class MemberServiceTest {
         val teamId = 1L
         val command = GetMembersCommand(accountId = accountId, teamId = teamId)
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { memberService.getMembers(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS.name)
             })
 
         then(loadMemberPort).shouldHaveNoInteractions()
@@ -121,7 +115,7 @@ class MemberServiceTest {
             member(id = 2L, teamId = teamId, accountId = 20L),
         )
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(true)
         given(loadMemberPort.loadAllByTeam(teamId)).willReturn(members)
 
         val result = memberService.getMembers(command)
@@ -138,15 +132,15 @@ class MemberServiceTest {
     fun invite_throwsException_whenNotAdmin() {
         val accountId = 10L
         val teamId = 1L
-        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, email = "target@test.com")
+        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, handle = "target")
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { memberService.invite(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveMemberPort).shouldHaveNoInteractions()
@@ -158,12 +152,12 @@ class MemberServiceTest {
         val accountId = 10L
         val teamId = 1L
         val targetAccountId = 20L
-        val email = "target@test.com"
-        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, email = email)
+        val handle = "target"
+        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, handle = handle)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
-        given(loadAccountForMemberPort.loadAccountIdByEmail(email)).willReturn(targetAccountId)
-        given(checkTeamMemberPort.isMember(targetAccountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
+        given(loadAccountForMemberPort.loadAccountIdByHandle(handle)).willReturn(targetAccountId)
+        given(checkMemberPort.isMember(targetAccountId, teamId)).willReturn(true)
 
         assertThatThrownBy { memberService.invite(command) }
             .isInstanceOf(MemberException::class.java)
@@ -181,14 +175,22 @@ class MemberServiceTest {
         val accountId = 10L
         val teamId = 1L
         val targetAccountId = 20L
-        val email = "target@test.com"
-        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, email = email)
-        val savedMember = member(id = 99L, teamId = teamId, accountId = targetAccountId, status = MemberStatus.INVITE, role = MemberRole.COMMON)
+        val handle = "target"
+        val command = InviteMemberCommand(accountId = accountId, teamId = teamId, handle = handle)
+        val savedMember = member(
+            id = 99L,
+            teamId = teamId,
+            accountId = targetAccountId,
+            status = MemberStatus.INVITE,
+            role = MemberRole.COMMON
+        )
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
-        given(loadAccountForMemberPort.loadAccountIdByEmail(email)).willReturn(targetAccountId)
-        given(checkTeamMemberPort.isMember(targetAccountId, teamId)).willReturn(false)
-        given(saveMemberPort.save(teamId, targetAccountId, MemberStatus.INVITE, MemberRole.COMMON)).willReturn(savedMember)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
+        given(loadAccountForMemberPort.loadAccountIdByHandle(handle)).willReturn(targetAccountId)
+        given(teamAccessPort.hasAccess(targetAccountId, teamId)).willReturn(false)
+        given(saveMemberPort.save(teamId, targetAccountId, MemberStatus.INVITE, MemberRole.COMMON)).willReturn(
+            savedMember
+        )
 
         val result = memberService.invite(command)
 
@@ -227,7 +229,8 @@ class MemberServiceTest {
         val memberId = 1L
         val command = AcceptInvitationCommand(accountId = accountId, teamId = teamId)
         val invitedMember = member(id = memberId, teamId = teamId, accountId = accountId, status = MemberStatus.INVITE)
-        val activatedMember = member(id = memberId, teamId = teamId, accountId = accountId, status = MemberStatus.ACTIVATE)
+        val activatedMember =
+            member(id = memberId, teamId = teamId, accountId = accountId, status = MemberStatus.ACTIVATE)
 
         given(loadMemberPort.loadByTeamAndAccount(teamId, accountId)).willReturn(invitedMember)
         given(saveMemberPort.activate(memberId)).willReturn(activatedMember)
@@ -305,15 +308,16 @@ class MemberServiceTest {
     fun updateRole_throwsException_whenNotAdmin() {
         val accountId = 10L
         val teamId = 1L
-        val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = 2L, role = MemberRole.ADMIN)
+        val command =
+            UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = 2L, role = MemberRole.ADMIN)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { memberService.updateRole(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveMemberPort).shouldHaveNoInteractions()
@@ -326,10 +330,16 @@ class MemberServiceTest {
         val teamId = 1L
         val otherTeamId = 99L
         val targetMemberId = 2L
-        val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = MemberRole.COMMON)
-        val memberInOtherTeam = member(id = targetMemberId, teamId = otherTeamId, accountId = 20L, role = MemberRole.ADMIN)
+        val command = UpdateMemberRoleCommand(
+            accountId = accountId,
+            teamId = teamId,
+            memberId = targetMemberId,
+            role = MemberRole.COMMON
+        )
+        val memberInOtherTeam =
+            member(id = targetMemberId, teamId = otherTeamId, accountId = 20L, role = MemberRole.ADMIN)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(memberInOtherTeam)
 
         assertThatThrownBy { memberService.updateRole(command) }
@@ -348,10 +358,15 @@ class MemberServiceTest {
         val accountId = 10L
         val teamId = 1L
         val targetMemberId = 2L
-        val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = MemberRole.COMMON)
+        val command = UpdateMemberRoleCommand(
+            accountId = accountId,
+            teamId = teamId,
+            memberId = targetMemberId,
+            role = MemberRole.COMMON
+        )
         val lastAdminMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = MemberRole.ADMIN)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(lastAdminMember)
         given(loadMemberPort.countByTeamAndRole(teamId, MemberRole.ADMIN)).willReturn(1L)
 
@@ -372,11 +387,12 @@ class MemberServiceTest {
         val teamId = 1L
         val targetMemberId = 2L
         val newRole = MemberRole.COMMON
-        val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = newRole)
+        val command =
+            UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = newRole)
         val targetMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = MemberRole.ADMIN)
         val updatedMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = newRole)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(targetMember)
         given(loadMemberPort.countByTeamAndRole(teamId, MemberRole.ADMIN)).willReturn(2L)
         given(saveMemberPort.updateRole(targetMemberId, newRole)).willReturn(updatedMember)
@@ -395,11 +411,12 @@ class MemberServiceTest {
         val teamId = 1L
         val targetMemberId = 2L
         val newRole = MemberRole.ADMIN
-        val command = UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = newRole)
+        val command =
+            UpdateMemberRoleCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId, role = newRole)
         val targetMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = MemberRole.COMMON)
         val updatedMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = newRole)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(targetMember)
         given(saveMemberPort.updateRole(targetMemberId, newRole)).willReturn(updatedMember)
 
@@ -419,13 +436,13 @@ class MemberServiceTest {
         val teamId = 1L
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = 2L)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { memberService.removeMember(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(deleteMemberPort).shouldHaveNoInteractions()
@@ -440,7 +457,7 @@ class MemberServiceTest {
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = memberId)
         val selfMember = member(id = memberId, teamId = teamId, accountId = accountId)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(memberId)).willReturn(selfMember)
 
         assertThatThrownBy { memberService.removeMember(command) }
@@ -462,7 +479,7 @@ class MemberServiceTest {
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId)
         val lastAdminMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = MemberRole.ADMIN)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(lastAdminMember)
         given(loadMemberPort.countByTeamAndRole(teamId, MemberRole.ADMIN)).willReturn(1L)
 
@@ -486,7 +503,7 @@ class MemberServiceTest {
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId)
         val memberInOtherTeam = member(id = targetMemberId, teamId = otherTeamId, accountId = 20L)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(memberInOtherTeam)
 
         assertThatThrownBy { memberService.removeMember(command) }
@@ -508,7 +525,7 @@ class MemberServiceTest {
         val command = RemoveMemberCommand(accountId = accountId, teamId = teamId, memberId = targetMemberId)
         val targetMember = member(id = targetMemberId, teamId = teamId, accountId = 20L, role = MemberRole.COMMON)
 
-        given(checkTeamMemberPort.isAdminMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.canManage(accountId, teamId)).willReturn(true)
         given(loadMemberPort.load(targetMemberId)).willReturn(targetMember)
 
         val result = memberService.removeMember(command)

--- a/src/test/kotlin/sharev/team/adapter/inbound/web/controller/TeamControllerTest.kt
+++ b/src/test/kotlin/sharev/team/adapter/inbound/web/controller/TeamControllerTest.kt
@@ -33,6 +33,7 @@ import sharev.team.application.port.inbound.usecase.UpdateTeamInfoUseCase
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.TeamCertification
+import sharev.team.domain.model.TeamType
 import java.time.LocalDateTime
 
 class TeamControllerTest : ControllerTestSupport() {
@@ -41,7 +42,7 @@ class TeamControllerTest : ControllerTestSupport() {
     @DisplayName("팀 생성")
     fun createTeam() {
         val requestDto = CreateTeamRequest("새로운 팀", "설명")
-        given(mockBean<CreateTeamUseCase>().create(CreateTeamCommand(1L, "새로운 팀", "설명")))
+        given(mockBean<CreateTeamUseCase>().create(CreateTeamCommand(1L, "새로운 팀", "설명", TeamType.PUBLIC)))
             .willReturn(CreateTeamResult(1L))
 
         val request = RestDocumentationRequestBuilders.post("/teams")
@@ -205,7 +206,7 @@ class TeamControllerTest : ControllerTestSupport() {
     @Test
     @WithCustomMockUser
     @DisplayName("팀 정보 수정 실패 - 팀 미존재 혹은 속하지 않음")
-    fun updateTeamInfoTeamFail() {
+    fun updateTeamInfoFail() {
         val requestDto = UpdateTeamRequest("수정된 팀 이름", "수정된 설명")
 
         willThrow(TeamException(TeamExceptionCode.TEAM_NOT_FOUND))
@@ -224,10 +225,10 @@ class TeamControllerTest : ControllerTestSupport() {
     @Test
     @WithCustomMockUser
     @DisplayName("팀 정보 수정 실패 - 권한 없음")
-    fun updateTeamInfoRoleFail() {
+    fun updateInfoRoleFail() {
         val requestDto = UpdateTeamRequest("수정된 팀 이름", "수정된 설명")
 
-        willThrow(TeamException(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER))
+        willThrow(TeamException(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE))
             .given(mockBean<UpdateTeamInfoUseCase>())
             .updateTeamInfo(UpdateTeamInfoCommand(1L, 1L, requestDto.title, requestDto.content))
 
@@ -243,7 +244,7 @@ class TeamControllerTest : ControllerTestSupport() {
     @Test
     @WithCustomMockUser
     @DisplayName("팀 정보 수정")
-    fun updateTeamInfo() {
+    fun updateInfo() {
         val updateTitle = "수정된 팀 이름"
         val updateContent = "수정된 팀 설명"
         val requestDto = UpdateTeamRequest(updateTitle, updateContent)

--- a/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
+++ b/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
@@ -7,53 +7,55 @@ import org.junit.jupiter.api.Test
 import org.mockito.BDDMockito.given
 import org.mockito.BDDMockito.then
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
 import sharev.member.domain.model.MemberRole
 import sharev.team.application.port.inbound.command.CreateTeamCommand
 import sharev.team.application.port.inbound.command.GetMyTeamsCommand
 import sharev.team.application.port.inbound.command.UpdateTeamInfoCommand
 import sharev.team.application.port.outbound.*
 import sharev.team.application.port.outbound.summary.GatheringSummary
+import sharev.team.application.port.outbound.summary.MyTeamSummary
 import sharev.team.application.port.outbound.summary.TeamMemberSummary
-import sharev.team.application.port.outbound.summary.TeamSummary
 import sharev.team.domain.exception.TeamException
 import sharev.team.domain.exception.TeamExceptionCode
 import sharev.team.domain.model.Team
 import sharev.team.domain.model.TeamCertification
+import sharev.team.domain.model.TeamType
 import java.time.LocalDateTime
 
 class TeamServiceTest {
     private val saveTeamPort = mock(SaveTeamPort::class.java)
     private val loadTeamPort = mock(LoadTeamPort::class.java)
     private val queryTeamPort = mock(QueryTeamPort::class.java)
-    private val saveTeamAdminMemberPort = mock(SaveTeamAdminMemberPort::class.java)
-    private val checkTeamMemberPort = mock(CheckTeamMemberPort::class.java)
-    private val loadGatheringSummaryPort = mock(LoadGatheringSummaryPort::class.java)
+    private val saveTeamAdminPort = mock(SaveTeamAdminPort::class.java)
+    private val teamAccessPort = mock(TeamAccessPort::class.java)
+    private val queryGatheringPort = mock(QueryGatheringPort::class.java)
 
     private val teamService = TeamService(
         saveTeamPort,
         loadTeamPort,
         queryTeamPort,
-        saveTeamAdminMemberPort,
-        checkTeamMemberPort,
-        loadGatheringSummaryPort,
+        saveTeamAdminPort,
+        teamAccessPort,
+        queryGatheringPort,
     )
 
     // ───────────── create ─────────────
 
     @Test
     @DisplayName("팀 생성 시 팀을 저장하고 admin 멤버를 자동 생성한다")
-    fun create_savesTeamAndCreatesAdminMember() {
+    fun create_PublicTeam_savesTeamAndCreatesAdminMember() {
         val accountId = 10L
-        val command = CreateTeamCommand(accountId, "새 팀", "설명")
-        val savedTeam = team(1L, command.title, command.content)
+        val command = CreateTeamCommand(accountId, "새 팀", "설명", TeamType.PUBLIC)
+        val savedTeam = team(1L, command.title!!, command.content!!)
 
-        given(saveTeamPort.save(command.title, command.content))
+        given(saveTeamPort.save(Team.create(command.title, command.content, command.type)))
             .willReturn(savedTeam)
 
         val result = teamService.create(command)
 
         assertThat(result.teamId).isEqualTo(savedTeam.id)
-        then(saveTeamAdminMemberPort).should().saveTeamAdmin(savedTeam.id, accountId)
+        then(saveTeamAdminPort).should().save(savedTeam.id, accountId)
     }
 
     // ───────────── getMyTeams ─────────────
@@ -86,13 +88,13 @@ class TeamServiceTest {
         val accountId = 10L
         val teamId = 1L
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(false)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(false)
 
         assertThatThrownBy { teamService.getTeamDetail(accountId, teamId) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_ACCESS.name)
             })
 
         then(loadTeamPort).shouldHaveNoInteractions()
@@ -114,9 +116,9 @@ class TeamServiceTest {
             teamMemberSummary(name = "이영희", email = "lee@test.com", role = MemberRole.COMMON),
         )
 
-        given(checkTeamMemberPort.isMember(accountId, teamId)).willReturn(true)
+        given(teamAccessPort.hasAccess(accountId, teamId)).willReturn(true)
         given(loadTeamPort.load(teamId)).willReturn(existingTeam)
-        given(loadGatheringSummaryPort.loadByTeam(teamId)).willReturn(gatheringSummaries)
+        given(queryGatheringPort.findByTeam(teamId)).willReturn(gatheringSummaries)
         given(queryTeamPort.findTeamMembers(teamId)).willReturn(memberSummaries)
 
         val result = teamService.getTeamDetail(accountId, teamId)
@@ -137,17 +139,17 @@ class TeamServiceTest {
 
     @Test
     @DisplayName("admin이 아니면 updateTeamInfo 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
-    fun updateTeamInfo_throwsException_whenNotAdmin() {
+    fun updateInfo_throwsException_whenNotAdmin() {
         val command = UpdateTeamInfoCommand(10L, 1L, "새 제목", "내용")
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId))
+        given(teamAccessPort.canManage(command.accountId, command.teamId))
             .willReturn(false)
 
         assertThatThrownBy { teamService.updateTeamInfo(command) }
             .isInstanceOf(TeamException::class.java)
             .satisfies({ ex ->
                 val teamEx = ex as TeamException
-                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.NOT_TEAM_ADMIN_MEMBER.name)
+                assertThat(teamEx.details.code).isEqualTo(TeamExceptionCode.UNAUTHORIZED_TEAM_MANAGE.name)
             })
 
         then(saveTeamPort).shouldHaveNoInteractions()
@@ -155,21 +157,24 @@ class TeamServiceTest {
 
     @Test
     @DisplayName("admin이면 updateTeamInfo 시 팀 제목을 수정하고 결과를 반환한다")
-    fun updateTeamInfo_updatesTitle_whenAdmin() {
+    fun updateInfo_updatesTitle_whenAdmin() {
         val newTitle = "수정된 팀 이름"
         val newContent = "수정된 내용"
         val command = UpdateTeamInfoCommand(10L, 1L, newTitle, newContent)
+        val beforeTeam = team(command.teamId, "수정 전 이름", "수정 전 내용")
         val updatedTeam = team(command.teamId, newTitle, newContent)
 
-        given(checkTeamMemberPort.isAdminMember(command.accountId, command.teamId))
+        given(teamAccessPort.canManage(command.accountId, command.teamId))
             .willReturn(true)
-        given(saveTeamPort.update(command.teamId, newTitle, newContent))
+        given(loadTeamPort.load(command.teamId))
+            .willReturn(beforeTeam)
+        given(saveTeamPort.updateTitleAndContent(team(beforeTeam.id, newTitle, newContent)))
             .willReturn(updatedTeam)
 
         val result = teamService.updateTeamInfo(command)
 
         assertThat(result.title).isEqualTo(newTitle)
-        then(saveTeamPort).should().update(command.teamId, newTitle, newContent)
+        then(saveTeamPort).should().updateTitleAndContent(any())
     }
 
     // ───────────── helpers ─────────────
@@ -180,16 +185,17 @@ class TeamServiceTest {
         content: String,
     ) = Team(
         id = id,
-        teamCertification = TeamCertification.NONE,
         title = title,
         content = content,
+        certification = TeamCertification.NONE,
+        type = TeamType.PUBLIC,
         createdAt = LocalDateTime.of(2026, 1, 1, 0, 0),
     )
 
     private fun teamSummary(
         id: Long,
         title: String,
-    ) = TeamSummary(
+    ) = MyTeamSummary(
         id = id,
         title = title,
         content = null,
@@ -213,7 +219,7 @@ class TeamServiceTest {
         role: MemberRole = MemberRole.COMMON,
     ) = TeamMemberSummary(
         name = name,
-        email = email,
         role = role,
+        email = email,
     )
 }

--- a/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
+++ b/src/test/kotlin/sharev/team/application/service/TeamServiceTest.kt
@@ -83,7 +83,7 @@ class TeamServiceTest {
     // ───────────── getTeamDetail ─────────────
 
     @Test
-    @DisplayName("팀 멤버가 아니면 getTeamDetail 시 NOT_TEAM_MEMBER 예외가 발생한다")
+    @DisplayName("팀 멤버가 아니면 getTeamDetail 시 UNAUTHORIZED_TEAM_ACCESS 예외가 발생한다")
     fun getTeamDetail_throwsException_whenNotTeamMember() {
         val accountId = 10L
         val teamId = 1L
@@ -138,7 +138,7 @@ class TeamServiceTest {
     // ───────────── updateTeamInfo ─────────────
 
     @Test
-    @DisplayName("admin이 아니면 updateTeamInfo 시 NOT_TEAM_ADMIN_MEMBER 예외가 발생한다")
+    @DisplayName("admin이 아니면 updateTeamInfo 시 UNAUTHORIZED_TEAM_MANAGE 예외가 발생한다")
     fun updateInfo_throwsException_whenNotAdmin() {
         val command = UpdateTeamInfoCommand(10L, 1L, "새 제목", "내용")
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * OAuth 회원가입 완료 시 개인 팀이 자동으로 생성됩니다.
  * 팀 유형에 공개 팀과 개인 팀이 추가되었습니다.
  * 회원 초대 시 이메일 대신 핸들을 사용합니다.
  * 팀 접근 권한과 관리 권한이 구분되어 적용됩니다.

* **변경 사항**
  * 공개 팀 생성 시 제목과 내용이 필수로 검증됩니다.
  * 개인 팀은 수정이 제한됩니다.
  * 회원 초대 API의 성공 응답이 `200 OK`로 변경되었습니다.
  * 팀 목록과 상세 정보에서 개인 팀의 제목이 비어 있을 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->